### PR TITLE
Add which command and look up the system binary manually

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,6 @@
 use exec_cmd;
 use shim_cmd;
+use which_cmd;
 use std::process;
 
 pub fn run() {
@@ -13,6 +14,10 @@ pub fn run() {
         )
         (@subcommand shim =>
             (about: "Generate shims for all managed commands")
+        )
+        (@subcommand which =>
+            (about: "Print the resolved path of a command")
+            (@arg command: +required "Command to look up")
         )
     ).get_matches();
 
@@ -28,6 +33,8 @@ pub fn run() {
                 &args
             )
         },
+        ("which", Some(matches)) =>
+            which_cmd::run(matches.value_of("command").unwrap()),
         ("shim", Some(_)) => shim_cmd::run(),
         ("", None) => {
             println!("Please specify a subcommand");

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,6 +1,7 @@
 use std::path::*;
 use std::env;
 use use_file;
+use config;
 
 pub fn find_selected_version(command: &str) -> Option<String> {
     let file = use_file::find(env::current_dir().unwrap())
@@ -11,6 +12,14 @@ pub fn find_selected_version(command: &str) -> Option<String> {
         .map(|version| version.to_owned())
 }
 
-pub fn find_system_bin(command_name: &str) -> Option<PathBuf> {
-    None
+pub fn find_system_bin(command: &str) -> Option<PathBuf> {
+    let shim_dir = config::shim_dir();
+    let path = env::var("PATH").expect("env var PATH is not defined");
+    let paths: Vec<_> = env::split_paths(&path)
+        .filter(|p| p != &shim_dir)
+        .collect();
+
+    paths.iter()
+        .find(|p| p.join(command).exists())
+        .map(|p| p.join(command))
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,0 +1,16 @@
+use std::path::*;
+use std::env;
+use use_file;
+
+pub fn find_selected_version(command: &str) -> Option<String> {
+    let file = use_file::find(env::current_dir().unwrap())
+        .map(|path| use_file::load(&path));
+
+    file.as_ref()
+        .and_then(|file| file.get(command))
+        .map(|version| version.to_owned())
+}
+
+pub fn find_system_bin(command_name: &str) -> Option<PathBuf> {
+    None
+}

--- a/src/def_file.rs
+++ b/src/def_file.rs
@@ -1,12 +1,13 @@
 extern crate toml;
 
 use std::collections::HashMap;
+use std::path::*;
 use std::fs;
 use config;
 
 const DEFS_FILE_NAME: &'static str = "defs.toml";
 
-pub type CommandVersions = HashMap<String, String>;
+pub type CommandVersions = HashMap<String, PathBuf>;
 pub type CommandDefs = HashMap<String, CommandVersions>;
 
 pub fn load() -> CommandDefs {
@@ -19,7 +20,7 @@ pub fn load() -> CommandDefs {
     }
 }
 
-pub fn find_bin<'a>(defs: &'a CommandDefs, command: &str, version: &str) -> Option<&'a String> {
+pub fn find_bin<'a>(defs: &'a CommandDefs, command: &str, version: &str) -> Option<&'a PathBuf> {
     defs.get(command).and_then(|def| def.get(version))
 }
 
@@ -40,8 +41,8 @@ mod tests {
     fn find_bin_returns_none_when_command_not_defined() {
         let mut defs = CommandDefs::new();
         let mut ruby = CommandVersions::new();
-        ruby.insert("2.4".to_string(), "/path/to/ruby2.4/bin/ruby".to_string());
-        ruby.insert("2.5".to_string(), "/path/to/ruby2.5/bin/ruby".to_string());
+        ruby.insert("2.4".to_string(), PathBuf::from("/path/to/ruby2.4/bin/ruby"));
+        ruby.insert("2.5".to_string(), PathBuf::from("/path/to/ruby2.5/bin/ruby"));
         defs.insert("ruby".to_string(), ruby);
 
         let res = find_bin(&defs, "python", "2");
@@ -53,8 +54,8 @@ mod tests {
     fn find_bin_returns_none_when_version_not_defined() {
         let mut defs = CommandDefs::new();
         let mut ruby = CommandVersions::new();
-        ruby.insert("2.4".to_string(), "/path/to/ruby2.4/bin/ruby".to_string());
-        ruby.insert("2.5".to_string(), "/path/to/ruby2.5/bin/ruby".to_string());
+        ruby.insert("2.4".to_string(), PathBuf::from("/path/to/ruby2.4/bin/ruby"));
+        ruby.insert("2.5".to_string(), PathBuf::from("/path/to/ruby2.5/bin/ruby"));
         defs.insert("ruby".to_string(), ruby);
 
         let res = find_bin(&defs, "ruby", "1.9");
@@ -66,14 +67,14 @@ mod tests {
     fn find_bin_returns_path_when_command_and_version_defined() {
         let mut defs = CommandDefs::new();
         let mut ruby = CommandVersions::new();
-        ruby.insert("2.4".to_string(), "/path/to/ruby2.4/bin/ruby".to_string());
-        ruby.insert("2.5".to_string(), "/path/to/ruby2.5/bin/ruby".to_string());
+        ruby.insert("2.4".to_string(), PathBuf::from("/path/to/ruby2.4/bin/ruby"));
+        ruby.insert("2.5".to_string(), PathBuf::from("/path/to/ruby2.5/bin/ruby"));
         defs.insert("ruby".to_string(), ruby);
 
         let res = find_bin(&defs, "ruby", "2.4");
 
         assert_eq!(
-            Some(&"/path/to/ruby2.4/bin/ruby".to_string()),
+            Some(&PathBuf::from("/path/to/ruby2.4/bin/ruby")),
             res
         )
     }

--- a/src/def_file.rs
+++ b/src/def_file.rs
@@ -9,23 +9,6 @@ const DEFS_FILE_NAME: &'static str = "defs.toml";
 pub type CommandVersions = HashMap<String, String>;
 pub type CommandDefs = HashMap<String, CommandVersions>;
 
-fn command_versions(raw_defs: String, command: &str) -> CommandVersions {
-    let all_defs: CommandDefs = toml::from_str(&raw_defs)
-        .expect("failed to parse definitions toml");
-
-    all_defs.get(command)
-        .map(|r| r.clone())
-        .unwrap_or_else(|| CommandVersions::new())
-}
-
-pub fn load_for(command: &str) -> CommandVersions {
-    let def_file_path = config::home_dir().join(DEFS_FILE_NAME);
-    match fs::read_to_string(def_file_path) {
-        Ok(contents) => command_versions(contents, command),
-        Err(_) => CommandVersions::new(),
-    }
-}
-
 pub fn load() -> CommandDefs {
     let path = config::home_dir().join(DEFS_FILE_NAME);
     if path.is_file() {
@@ -33,5 +16,65 @@ pub fn load() -> CommandDefs {
         toml::from_slice(&bytes).expect("failted to parse defs file toml")
     } else {
         CommandDefs::new()
+    }
+}
+
+pub fn find_bin<'a>(defs: &'a CommandDefs, command: &str, version: &str) -> Option<&'a String> {
+    defs.get(command).and_then(|def| def.get(version))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_bin_returns_none_on_empty_defs() {
+        let defs = CommandDefs::new();
+
+        let res = find_bin(&defs, "python", "2");
+
+        assert_eq!(None, res)
+    }
+
+    #[test]
+    fn find_bin_returns_none_when_command_not_defined() {
+        let mut defs = CommandDefs::new();
+        let mut ruby = CommandVersions::new();
+        ruby.insert("2.4".to_string(), "/path/to/ruby2.4/bin/ruby".to_string());
+        ruby.insert("2.5".to_string(), "/path/to/ruby2.5/bin/ruby".to_string());
+        defs.insert("ruby".to_string(), ruby);
+
+        let res = find_bin(&defs, "python", "2");
+
+        assert_eq!(None, res)
+    }
+
+    #[test]
+    fn find_bin_returns_none_when_version_not_defined() {
+        let mut defs = CommandDefs::new();
+        let mut ruby = CommandVersions::new();
+        ruby.insert("2.4".to_string(), "/path/to/ruby2.4/bin/ruby".to_string());
+        ruby.insert("2.5".to_string(), "/path/to/ruby2.5/bin/ruby".to_string());
+        defs.insert("ruby".to_string(), ruby);
+
+        let res = find_bin(&defs, "ruby", "1.9");
+
+        assert_eq!(None, res)
+    }
+
+    #[test]
+    fn find_bin_returns_path_when_command_and_version_defined() {
+        let mut defs = CommandDefs::new();
+        let mut ruby = CommandVersions::new();
+        ruby.insert("2.4".to_string(), "/path/to/ruby2.4/bin/ruby".to_string());
+        ruby.insert("2.5".to_string(), "/path/to/ruby2.5/bin/ruby".to_string());
+        defs.insert("ruby".to_string(), ruby);
+
+        let res = find_bin(&defs, "ruby", "2.4");
+
+        assert_eq!(
+            Some(&"/path/to/ruby2.4/bin/ruby".to_string()),
+            res
+        )
     }
 }

--- a/src/exec_cmd.rs
+++ b/src/exec_cmd.rs
@@ -1,22 +1,24 @@
-use use_file;
 use def_file;
-use std::env;
+use command;
 use std::os::unix::process::CommandExt;
 use std::process::Command;
 
 pub fn run(command: &str, command_args: &Vec<String>) {
     let system_command = String::from(command);
 
-    let command_def = def_file::load_for(&command);
+    let defs = def_file::load();
+    let command_version = command::find_selected_version(&command);
 
-    let file = use_file::find(env::current_dir().unwrap())
-        .map(|path| use_file::load(&path));
-    let command_version = file.as_ref()
-        .and_then(|file| file.get(command));
-
-    let bin = command_version
-        .and_then(|v| command_def.get(v))
-        .unwrap_or(&system_command);
+    let bin = match command_version {
+        Some(version) => {
+            def_file::find_bin(&defs, command, &version)
+                .expect(&format!("version {} of command {} is not defined",
+                    version,
+                    command
+                ))
+        },
+        None => &system_command
+    };
 
     let err = Command::new(&bin)
         .args(command_args)

--- a/src/exec_cmd.rs
+++ b/src/exec_cmd.rs
@@ -1,33 +1,40 @@
 use def_file;
 use command;
 use std::os::unix::process::CommandExt;
+use std::process;
 use std::process::Command;
 
 pub fn run(command: &str, command_args: &Vec<String>) {
-    let system_command = String::from(command);
-
     let defs = def_file::load();
     let command_version = command::find_selected_version(&command);
 
-    let bin = match command_version {
-        Some(version) => {
+    let bin = command_version
+        .map(|version| {
             def_file::find_bin(&defs, command, &version)
                 .expect(&format!("version {} of command {} is not defined",
                     version,
                     command
                 ))
+                .to_owned()
+        })
+        .or_else(|| command::find_system_bin(command));
+
+    match bin {
+        Some(bin) => {
+            let err = Command::new(&bin)
+                .args(command_args)
+                .exec();
+
+            // Since we're callling exec, either our process will be replaced
+            // (and this code will never be called) or something's wrong and
+            // we get this error
+            eprintln!("Failed to exec()!");
+            eprintln!("{:#?}", err);
+            panic!();
         },
-        None => &system_command
-    };
-
-    let err = Command::new(&bin)
-        .args(command_args)
-        .exec();
-
-    // Since we're callling exec, either our process will be replaced
-    // (and this code will never be called) or something's wrong and
-    // we get this error
-    eprintln!("Failed to exec()!");
-    eprintln!("{:#?}", err);
-    panic!();
+        None => {
+            println!("command not found: {}", command);
+            process::exit(1)
+        },
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,10 @@ mod use_file;
 mod def_file;
 mod exec_cmd;
 mod shim_cmd;
+mod which_cmd;
 mod cli;
 mod shim;
+mod command;
 
 use std::env;
 

--- a/src/which_cmd.rs
+++ b/src/which_cmd.rs
@@ -1,3 +1,21 @@
-pub fn run(command: &str) {
+use def_file;
+use command;
+use std::process;
 
+pub fn run(command: &str) {
+    let defs = def_file::load();
+    let command_version = command::find_selected_version(&command);
+
+    let bin = command_version
+        .and_then(|version| def_file::find_bin(&defs, command, &version))
+        .map(|bin| bin.to_owned())
+        .or_else(|| command::find_system_bin(command));
+
+    match bin {
+        Some(bin) => println!("{}", bin.to_str().unwrap()),
+        None => {
+            println!("command not found: {}", command);
+            process::exit(1)
+        },
+    };
 }

--- a/src/which_cmd.rs
+++ b/src/which_cmd.rs
@@ -1,0 +1,3 @@
+pub fn run(command: &str) {
+
+}


### PR DESCRIPTION
Fixes #3 

Before this, we used to blindly try to blindly run the command if we didn't find a definition. Now we try to find the system version of the command.

To test this, I also added a `alt which <command>` command that returns the path of the command to run.

Also, exec has been made slightly more rigid. When you define a version of a command and it's impossible for us to get it, it'll crash instead of falling back onto the system version.