### PR TITLE
Add use command

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,23 +92,14 @@ alt shim
 
 ### Switching command versions
 
-Currently, `alt` only supports switching versions of commands based on the
-current directory. The idea is to let you define which versions of a command you
-want to use for your project.
+`alt` uses the directory you're currently in to figure out which versions of
+commands to run. When switching versions, everything is related to the current
+directory.
 
-1.  Go to the root of a directory tree where you want to use a different command
-
-    ```sh
-    cd path/to/your/project
-    ```
-
-1.  Create a file named `.alt.toml`
-
-    ```toml
-    # Associate a command to a version defined in the command definition file
-    node = "8"
-    python = "3"
-    ```
+```sh
+cd directory/of/interest
+alt use some-command
+```
 
 ## Development
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,8 +26,8 @@ pub fn run() {
             (@arg command: +required "Command to scan for")
         )
         (@subcommand use =>
-            (about: "Use a specific version of a command")
-            (@arg command: +required "Command who's version to select")
+            (about: "Swtich the version of a command")
+            (@arg command: +required "Command who's version to switch")
             (@arg version: "Version to use (will prompt if ommitted)")
         )
     )

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,6 +2,7 @@ use exec_cmd;
 use shim_cmd;
 use which_cmd;
 use scan_cmd;
+use use_cmd;
 use clap::AppSettings;
 
 pub fn run() {
@@ -24,6 +25,11 @@ pub fn run() {
             (about: "Scan for different versions of the given command")
             (@arg command: +required "Command to scan for")
         )
+        (@subcommand use =>
+            (about: "Use a specific version of a command")
+            (@arg command: +required "Command who's version to select")
+            (@arg version: "Version to use (will prompt if ommitted)")
+        )
     )
         .setting(AppSettings::SubcommandRequiredElseHelp)
         .get_matches();
@@ -45,6 +51,11 @@ pub fn run() {
         ("shim", Some(_)) => shim_cmd::run(),
         ("scan", Some(matches)) =>
             scan_cmd::run(matches.value_of("command").unwrap()),
+        ("use", Some(matches)) =>
+            use_cmd::run(
+                matches.value_of("command").unwrap(),
+                matches.value_of("version")
+            ),
         _ => unreachable!(),
     };
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -4,7 +4,7 @@ use use_file;
 use config;
 
 pub fn find_selected_version(command: &str) -> Option<String> {
-    let file = use_file::find(env::current_dir().unwrap())
+    let file = use_file::find(&env::current_dir().unwrap())
         .map(|path| use_file::load(&path));
 
     file.as_ref()

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod exec_cmd;
 mod shim_cmd;
 mod which_cmd;
 mod scan_cmd;
+mod use_cmd;
 mod cli;
 mod shim;
 mod command;

--- a/src/use_cmd.rs
+++ b/src/use_cmd.rs
@@ -1,0 +1,39 @@
+use def_file;
+use use_file;
+use std::process;
+use std::env;
+
+pub fn run(command: &str, arg_version: Option<&str>) {
+    let defs = def_file::load();
+
+    let command_versions = defs.get(command)
+        .unwrap_or_else(|| {
+            println!("Unknown command {}", command);
+            println!("Did you forget to define it? (see alt help scan)");
+            process::exit(1);
+        });
+
+    // TODO: prompt version if missing
+    let version = arg_version.unwrap();
+    let bin = command_versions.get(version)
+        .unwrap_or_else(|| {
+            println!("Unknown version {} for command {}", version, command);
+            println!("Did you forget to define it? (see alt help scan)");
+            process::exit(2);
+        });
+
+    let cwd = env::current_dir().unwrap();
+    let use_file = use_file::find_or_dir(&cwd);
+    let mut use_def = use_file::load(&use_file);
+    use_def.insert(String::from(command), String::from(version));
+    use_file::save(&use_def, &use_file)
+        .expect(&format!("Failed to write use file to {}", use_file.to_str().unwrap()));
+
+    println!(
+        "Will now use {} {} ({}) when in {}",
+        command,
+        version,
+        bin.to_str().unwrap(),
+        use_file.parent().unwrap().to_str().unwrap()
+    );
+}

--- a/src/use_file.rs
+++ b/src/use_file.rs
@@ -2,11 +2,13 @@ extern crate toml;
 
 use std::collections::HashMap;
 use std::fs;
+use std::io;
 use std::path::{PathBuf, Path};
 
 const FILE_NAME: &'static str = ".alt.toml";
 
-pub fn find(mut dir: PathBuf) -> Option<PathBuf> {
+pub fn find(start: &Path) -> Option<PathBuf> {
+    let mut dir = PathBuf::from(start);
     loop {
         let file = dir.join(FILE_NAME);
 
@@ -22,6 +24,11 @@ pub fn find(mut dir: PathBuf) -> Option<PathBuf> {
     }
 }
 
+pub fn find_or_dir(start: &Path) -> PathBuf {
+    find(start)
+        .unwrap_or_else(|| PathBuf::from(start))
+}
+
 pub type UseFile = HashMap<String, String>;
 
 pub fn load(path: &Path) -> UseFile {
@@ -29,4 +36,10 @@ pub fn load(path: &Path) -> UseFile {
         .expect("failed to read use file");
 
     toml::from_slice(&contents).unwrap()
+}
+
+pub fn save(use_def: &UseFile, path: &Path) -> Result<(), io::Error> {
+    let toml = toml::to_string_pretty(use_def)
+        .expect("failed to serialize use toml");
+    fs::write(path, toml)
 }


### PR DESCRIPTION
Closes #7 

This PR adds the `use` command.

The command is

```sh
alt use {command} {version}
```
If you don't specify the version, it'll prompt you for one