### PR TITLE
Fix crash when `alt use ...` with no `.alt.toml` file

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -5,7 +5,7 @@ use config;
 
 pub fn find_selected_version(command: &str) -> Option<String> {
     let file = use_file::find(&env::current_dir().unwrap())
-        .map(|path| use_file::load(&path));
+        .and_then(|path| use_file::load(&path));
 
     file.as_ref()
         .and_then(|file| file.get(command))

--- a/src/show_cmd.rs
+++ b/src/show_cmd.rs
@@ -14,7 +14,8 @@ pub fn run() {
     }
 
     let use_file = use_file::find(&env::current_dir().unwrap());
-    let used_versions = use_file.as_ref().map(|path| use_file::load(&path));
+    let used_versions = use_file.as_ref()
+        .and_then(|path| use_file::load(&path));
 
     if use_file.is_some() {
         println!("Versions from: {}", use_file.unwrap().to_str().unwrap());

--- a/src/use_cmd.rs
+++ b/src/use_cmd.rs
@@ -27,7 +27,7 @@ pub fn run(command: &str, arg_version: Option<&str>) {
 
     let cwd = env::current_dir().unwrap();
     let use_file = use_file::find_or_dir(&cwd);
-    let mut use_def = use_file::load(&use_file);
+    let mut use_def = use_file::load(&use_file).unwrap_or_default();
     use_def.insert(String::from(command), String::from(version));
     use_file::save(&use_def, &use_file)
         .expect(&format!("Failed to write use file to {}", use_file.to_str().unwrap()));

--- a/src/use_file.rs
+++ b/src/use_file.rs
@@ -26,16 +26,15 @@ pub fn find(start: &Path) -> Option<PathBuf> {
 
 pub fn find_or_dir(start: &Path) -> PathBuf {
     find(start)
-        .unwrap_or_else(|| PathBuf::from(start))
+        .unwrap_or_else(|| start.join(FILE_NAME))
 }
 
 pub type UseFile = HashMap<String, String>;
 
-pub fn load(path: &Path) -> UseFile {
-    let contents = fs::read(path)
-        .expect("failed to read use file");
-
-    toml::from_slice(&contents).unwrap()
+pub fn load(path: &Path) -> Option<UseFile> {
+    fs::read(path)
+        .ok()
+        .map(|contents| toml::from_slice(&contents).unwrap())
 }
 
 pub fn save(use_def: &UseFile, path: &Path) -> Result<(), io::Error> {


### PR DESCRIPTION
Closes #11