### PR TITLE
Use bash instead of sh in install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Tool for switching between different versions of commands.
 1.  Install alt
 
     ```sh
-    curl -sL https://github.com/dotboris/alt/raw/master/install.sh | sh -s
+    curl -sL https://github.com/dotboris/alt/raw/master/install.sh | bash -s
     ```
 
 1.  Add the shims directory to your `PATH` environment variable

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e -o pipefail
 
 get_latest_version() {
@@ -30,7 +30,7 @@ echo "You may be prompted for your password"
 file_name="alt_$os"
 url="https://github.com/dotboris/alt/releases/download/$version/$file_name"
 
-sudo sh -e -o pipefail -s <<SH
+sudo bash -e -o pipefail -s <<SH
   curl --progress-bar -L "$url" -o /usr/local/bin/alt
   chmod +x /usr/local/bin/alt
 SH


### PR DESCRIPTION
Closes #23 

This guarentees that the install script will work on all systems instead of sometimes failing when hitting dash instead of bash as the sh alias