### PR TITLE
Tolerate dir in `PATH` not existing during scan

### DIFF
--- a/src/scan/path_suffix.rs
+++ b/src/scan/path_suffix.rs
@@ -27,7 +27,7 @@ pub fn scan(command: &str) -> Vec<CommandVersion> {
 
     env::split_paths(&path)
         .filter(|p| p != &shim_dir)
-        .flat_map(|p| fs::read_dir(p).unwrap())
+        .flat_map(|p| fs::read_dir(p).ok()).flatten()
         .map(|bin| bin.unwrap().path())
         .flat_map(|bin| parse_command_version(bin))
         .filter(|c| c.command == command)

--- a/src/scan/path_suffix.rs
+++ b/src/scan/path_suffix.rs
@@ -27,7 +27,8 @@ pub fn scan(command: &str) -> Vec<CommandVersion> {
 
     env::split_paths(&path)
         .filter(|p| p != &shim_dir)
-        .flat_map(|p| fs::read_dir(p).ok()).flatten()
+        .filter(|p| p.is_dir())
+        .flat_map(|p| fs::read_dir(p).unwrap())
         .map(|bin| bin.unwrap().path())
         .flat_map(|bin| parse_command_version(bin))
         .filter(|c| c.command == command)


### PR DESCRIPTION
Closes #21 

We now just ignore any directory read that fails. This is a little aggressive but it catches all kinds of errors including permission issues and fs quirks