### PR TITLE
Speed up and simplify the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ install:
   - cargo install cross || true
 
 script:
-  - cross build --target "$TARGET"
-  - if [ -z "$DISABLE_TESTS" ]; then cross test --target "$TARGET" --features travis_ci; fi
-  - if [ -z "$DISABLE_TESTS" ]; then cross run --target "$TARGET" help; fi
+  - cross build --target "$TARGET" --release
+  - cross test --target "$TARGET" --release
+  - cross run --target "$TARGET" --release
 
 before_deploy:
   - cross build --target "$TARGET" --release

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,11 @@ script:
   - cargo run --target "$TARGET" --release help
 
   # Package for the release
-  - mkdir -p dist dist/gz-bin
-  - mv "target/$TARGET/release/alt" dist/bin/alt
-  - export VERSION="$(dist/alt --version | cut -d ' ' -f 2)"
-  - gzip -fk9 dist/alt
-  - mv dist/alt.gz "dist/gz-bin/alt_${VERSION}_$TARGET.gz"
+  - |
+    ./ci/package.py \
+      --alt-bin "target/$TARGET/release/alt" \
+      --rust-target "$TARGET" \
+      --dest-dir dist
   - ls -laR dist
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ script:
       --alt-bin "target/$TARGET/release/alt" \
       --rust-target "$TARGET" \
       --dest-dir dist
-  - ls -laR dist
+  - find dist -print0 | xargs -0 ls -lhd
 
 deploy:
   api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ matrix:
     - env: TARGET=x86_64-unknown-linux-musl
       rust: nightly
 
+install:
+  - rustup target add "$TARGET"
+
 script:
   - cargo build --target "$TARGET" --release
   - cargo test --target "$TARGET" --release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,4 @@
-# Based on the "trust" template v0.1.2
-# https://github.com/japaric/trust/tree/v0.1.2
-
-dist: trusty
 language: rust
-services: docker
-sudo: required
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,15 +29,18 @@ script:
   - cargo test --target "$TARGET" --release
   - cargo run --target "$TARGET" --release help
 
-before_deploy:
-  - gzip -fk9 "target/$TARGET/release/alt"
-  - mv "target/$TARGET/release/alt.gz" "alt_${TRAVIS_TAG}_$TARGET.gz"
+  # Package for the release
+  - mkdir dist
+  - mv "target/$TARGET/release/alt" dist/alt
+  - gzip -fk9 dist/alt
+  - mv dist/alt.gz "dist/alt_${TRAVIS_BRANCH}_$TARGET.gz"
+  - ls -la dist
 
 deploy:
   api_key:
     secure: "q6pEft0t1WB4Magi06K/EPgYRqVpEynC1bhYc9Sal3zenOjY2z1zyPPcpVTPY0ewP8r2Phf+W1pOF+crTyWnRJv1sFCT7wkKoW22vLOSNYnrf3S2PxqNmibNQiUnI9jtI6fGsx9mXyKp1SyEPuuv/a4PntQGjEd9NKIFG2o1XqvuF4bAUVYymv7tK/DEDtEqQGUAkrhmEJrN5G+j3iKZqZ0RpzibTxGvO5FWKS91xQTz88QIbEqADai9l0cncuApA1dOlxfwGMPN2vQ5/LqSsrDqGXS7347E/KyJgmK4T6q5Gs/TdlERr7bzGc1odhuHZraSnxwvB+nlKxnp3YkT5GjrnkVCisOIu8cmPOHJfdT3yq7HqPhE07UkR9fP6aH/WkzbbneJyCcCfVAkrZkT21WnyG+GUkjF49X7zn5T6lHcwuY/F25Zep9CUG/iZzDQ+PCqU6GKHnNgObHac/lDmu/dn33FKyFNsogTeGQUmcE6AGQgMOU+XV7bj/1AcgQdBbVby9kv4hu4xBI4y+w295hRBiXl1cy5gWD39SJwpnBMpHioiXb53pkKfbcT2G16vvjCeK9BLJF+eZ6zkq3kxvYV3PzQnGcDph0OhleLkzIdI/BZCc6jWu3YG0rdRXBv6zQefKgbLytxe+T+QI4QgIglImnUr6OrBY3SLZtzd5g="
   file_glob: true
-  file: "alt_${TRAVIS_TAG}_$TARGET.gz"
+  file: "dist/alt_${TRAVIS_BRANCH}_$TARGET.gz"
   on:
     condition: $TRAVIS_RUST_VERSION = stable
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,11 @@ script:
   - cargo run --target "$TARGET" --release help
 
   # Package for the release
-  - export VERSION="$(cargo run -- --version)"
-  - mkdir -p dist/bin dist/gz-bin
+  - mkdir -p dist dist/gz-bin
   - mv "target/$TARGET/release/alt" dist/bin/alt
-  - gzip -fk9 dist/bin/alt
-  - mv dist/bin/alt.gz "dist/gz-bin/alt_${VERSION}_$TARGET.gz"
+  - export VERSION="$(dist/alt --version | cut -d ' ' -f 2)"
+  - gzip -fk9 dist/alt
+  - mv dist/alt.gz "dist/gz-bin/alt_${VERSION}_$TARGET.gz"
   - ls -laR dist
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,17 +30,18 @@ script:
   - cargo run --target "$TARGET" --release help
 
   # Package for the release
-  - mkdir dist
-  - mv "target/$TARGET/release/alt" dist/alt
-  - gzip -fk9 dist/alt
-  - mv dist/alt.gz "dist/alt_${TRAVIS_BRANCH}_$TARGET.gz"
-  - ls -la dist
+  - export VERSION="$(cargo run -- --version)"
+  - mkdir -p dist/bin dist/gz-bin
+  - mv "target/$TARGET/release/alt" dist/bin/alt
+  - gzip -fk9 dist/bin/alt
+  - mv dist/bin/alt.gz "dist/gz-bin/alt_${VERSION}_$TARGET.gz"
+  - ls -laR dist
 
 deploy:
   api_key:
     secure: "q6pEft0t1WB4Magi06K/EPgYRqVpEynC1bhYc9Sal3zenOjY2z1zyPPcpVTPY0ewP8r2Phf+W1pOF+crTyWnRJv1sFCT7wkKoW22vLOSNYnrf3S2PxqNmibNQiUnI9jtI6fGsx9mXyKp1SyEPuuv/a4PntQGjEd9NKIFG2o1XqvuF4bAUVYymv7tK/DEDtEqQGUAkrhmEJrN5G+j3iKZqZ0RpzibTxGvO5FWKS91xQTz88QIbEqADai9l0cncuApA1dOlxfwGMPN2vQ5/LqSsrDqGXS7347E/KyJgmK4T6q5Gs/TdlERr7bzGc1odhuHZraSnxwvB+nlKxnp3YkT5GjrnkVCisOIu8cmPOHJfdT3yq7HqPhE07UkR9fP6aH/WkzbbneJyCcCfVAkrZkT21WnyG+GUkjF49X7zn5T6lHcwuY/F25Zep9CUG/iZzDQ+PCqU6GKHnNgObHac/lDmu/dn33FKyFNsogTeGQUmcE6AGQgMOU+XV7bj/1AcgQdBbVby9kv4hu4xBI4y+w295hRBiXl1cy5gWD39SJwpnBMpHioiXb53pkKfbcT2G16vvjCeK9BLJF+eZ6zkq3kxvYV3PzQnGcDph0OhleLkzIdI/BZCc6jWu3YG0rdRXBv6zQefKgbLytxe+T+QI4QgIglImnUr6OrBY3SLZtzd5g="
   file_glob: true
-  file: "dist/alt_${TRAVIS_BRANCH}_$TARGET.gz"
+  file: "dist/gz-bin/*"
   on:
     condition: $TRAVIS_RUST_VERSION = stable
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,17 +27,12 @@ matrix:
     - env: TARGET=x86_64-unknown-linux-gnu
       rust: nightly
 
-install:
-  - source ~/.cargo/env || true
-  - cargo install cross || true
-
 script:
-  - cross build --target "$TARGET" --release
-  - cross test --target "$TARGET" --release
-  - cross run --target "$TARGET" --release
+  - cargo build --target "$TARGET" --release
+  - cargo test --target "$TARGET" --release
+  - cargo run --target "$TARGET" --release help
 
 before_deploy:
-  - cross build --target "$TARGET" --release
   - gzip -fk9 "target/$TARGET/release/alt"
   - mv "target/$TARGET/release/alt.gz" "alt_${TRAVIS_TAG}_$TARGET.gz"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,10 +41,13 @@ deploy:
   provider: releases
   skip_cleanup: true
 
-cache: cargo
+# Cache ~/.cargo without ~/.cargo/registry. Also don't cache ./target
+# See: https://levans.fr/rust_travis_cache.html
+cache:
+  directories:
+    - /home/travis/.cargo
 before_cache:
-  # Travis can't cache files that are not readable by "others"
-  - chmod -R a+r $HOME/.cargo
+  - rm -rf /home/travis/.cargo/registry
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,35 +17,14 @@ matrix:
     - rust: nightly
 
   include:
-    # Linux
-    - env: TARGET=aarch64-unknown-linux-gnu
-    - env: TARGET=arm-unknown-linux-gnueabi
-    - env: TARGET=armv7-unknown-linux-gnueabihf
-    - env: TARGET=i686-unknown-linux-gnu
     - env: TARGET=x86_64-unknown-linux-gnu
-
-    # OSX
-    - env: TARGET=i686-apple-darwin
-      os: osx
     - env: TARGET=x86_64-apple-darwin
       os: osx
-
-    # TODO: BSD fails to build. Not sure why
-    # *BSD
-    #- env: TARGET=i686-unknown-freebsd DISABLE_TESTS=1
-    #- env: TARGET=x86_64-unknown-freebsd DISABLE_TESTS=1
-    #- env: TARGET=x86_64-unknown-netbsd DISABLE_TESTS=1
 
     # Testing other channels
     - env: TARGET=x86_64-unknown-linux-gnu
       rust: beta
-    - env: TARGET=x86_64-apple-darwin
-      os: osx
-      rust: beta
     - env: TARGET=x86_64-unknown-linux-gnu
-      rust: nightly
-    - env: TARGET=x86_64-apple-darwin
-      os: osx
       rust: nightly
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,14 @@ matrix:
     - rust: nightly
 
   include:
-    - env: TARGET=x86_64-unknown-linux-gnu
+    - env: TARGET=x86_64-unknown-linux-musl
     - env: TARGET=x86_64-apple-darwin
       os: osx
 
     # Testing other channels
-    - env: TARGET=x86_64-unknown-linux-gnu
+    - env: TARGET=x86_64-unknown-linux-musl
       rust: beta
-    - env: TARGET=x86_64-unknown-linux-gnu
+    - env: TARGET=x86_64-unknown-linux-musl
       rust: nightly
 
 script:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,6 @@ authors = ["Boris Bera <bera.boris@gmail.com>"]
 build = "build.rs"
 publish = false
 
-[features]
-# This is a bullshit feature used to disable some tests from running in certain
-# funny edge cases.
-travis_ci = []
-
 [dependencies]
 clap = "2.33.0"
 toml = "0.5.0"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,4 +1,0 @@
-[build.env]
-passthrough = [
-    "RUST_BACKTRACE",
-]

--- a/ci/package.py
+++ b/ci/package.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+import subprocess
+from os import path, makedirs
+from shutil import copy, move
+from argparse import ArgumentParser
+
+def sh(*args):
+    return subprocess.run(
+        args,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def parse():
+    parser = ArgumentParser()
+    parser.add_argument('--alt-bin', required=True)
+    parser.add_argument('--dest-dir', required=True)
+    parser.add_argument('--rust-target', required=True)
+    return parser.parse_args()
+
+
+def main(
+    alt_bin=None,
+    dest_dir=None,
+    rust_target=None,
+):
+    makedirs(dest_dir, exist_ok=True)
+    dest_alt_bin = path.join(dest_dir, 'alt')
+    copy(alt_bin, dest_alt_bin)
+
+    version = sh(dest_alt_bin, '--version').stdout
+    version = version.strip().split(' ')[1]
+
+    gz_dir = path.join(dest_dir, 'gz-bin')
+    makedirs(gz_dir, exist_ok=True)
+    sh('gzip', '-fk9', dest_alt_bin)
+    move(
+        '{0}.gz'.format(dest_alt_bin),
+        path.join(gz_dir, 'alt_v{0}_{1}.gz'.format(version, rust_target))
+    )
+
+
+if __name__ == "__main__":
+    args = parse()
+    main(**vars(args))

--- a/ci/package.py
+++ b/ci/package.py
@@ -1,16 +1,11 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python2
 import subprocess
-from os import path, makedirs
+from os import path, mkdir
 from shutil import copy, move
 from argparse import ArgumentParser
 
 def sh(*args):
-    return subprocess.run(
-        args,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+    return subprocess.check_output(args)
 
 
 def parse():
@@ -26,15 +21,15 @@ def main(
     dest_dir=None,
     rust_target=None,
 ):
-    makedirs(dest_dir, exist_ok=True)
+    mkdir(dest_dir)
     dest_alt_bin = path.join(dest_dir, 'alt')
     copy(alt_bin, dest_alt_bin)
 
-    version = sh(dest_alt_bin, '--version').stdout
+    version = sh(dest_alt_bin, '--version')
     version = version.strip().split(' ')[1]
 
     gz_dir = path.join(dest_dir, 'gz-bin')
-    makedirs(gz_dir, exist_ok=True)
+    mkdir(gz_dir)
     sh('gzip', '-fk9', dest_alt_bin)
     move(
         '{0}.gz'.format(dest_alt_bin),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,23 +1,3 @@
-#![cfg(not(all(
-    any(target_arch = "arm", target_arch = "aarch64"),
-    feature = "travis_ci"
-)))]
-// Long story short: the integration tests don't work and will not work
-// in travis-ci on arm.
-//
-// Long story long:
-// These tests work by executing the `alt` binary for the current
-// release & target. This is done in two ways:
-// - Direct call with the Command module
-// - Indirect call through a shim (symlink pointing to the alt binary)
-//
-// This is usually fine since you tend to build binaries for the os you
-// currently run. When building arm on travis, things break down.
-// We're building arm binaries on a x64 machine that we can't run directly.
-// `cross` runs arm binaries through `qemu-arm` (QEMU user mode).
-// I think that it's possible to setup QEMU user mode to work seemlessly on
-// linux, but I'm not going to bother with it for now.
-
 extern crate assert_cmd;
 
 use assert_cmd::prelude::*;


### PR DESCRIPTION
I have a few issues with the current build.

First, it's slow. This makes it so that development has to wait for the build to finish to do anything. This slows down my own dev process.

Second, it's complex. There are tons of jobs that build for all kinds of systems that are kind-of supported (#31, #33).

Third, changes to the release pipeline can't really be tested. You can build / test / run a release when you tag. If I want to change the release process, then I have to play the guessing game and get breakage when I release next.

The goal here is to make the build fast & simple enough that I can work on adding things like proper packages (#42, #41)