### PR TITLE
Migrate install instructions away from `curl ... | bash` type script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `alt scan` now knows about LinuxBrew and can automatically find different
   version of commands installed through LinuxBrew.
+- Add install instructions for Mac OSX using the Homebrew package manager.
+  (LinuxBrew also supported)
+- Add install instructions for `DEB` based linux systems.
+- Add install instructions using the pre-built `.tar.gz` release.
+- Add install from source instructions.
+- Document how to troubleshoot the warning emitted by `alt` when the shim
+  directory is not present in the `PATH` environment variable.
+- Add Homebrew formula update to release instructions.
 
 ### Changed
 
 - Move the shims directory higher up in the `PATH` on fish by using
-  `fish_user_paths`
+  `fish_user_paths`.
+- Expand documentation on `alt` in relation to git (and other VCS).
+- Update link to rust install instructions.
+- Update the shims dir not in `PATH` warning to include troubleshooting steps
+  and to link to the troubleshooting documentation.
+
+### Removed
+
+- The gziped `alt` binary (`alt_{...}.gz`) is no longer packaged.
+- Remove support for the `curl ... | bash -s` install method.
+
+### Fixed
+
+- Fix crash when `alt` is run without the `PATH` environment variable set.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ itself in a few ways:
 1.  OR Install the `.deb` file from the command line
 
     ```sh
-    sudo apt install path/to/alt.deb
+    sudo apt install ./path/to/alt.deb
     ```
 
 You will probably need to log out & log back in to your desktop session for

--- a/README.md
+++ b/README.md
@@ -155,12 +155,13 @@ Behind the scenes, `alt` manages a directory of "shims"
 (`$HOME/.local/alt/shims`). In order to switch the version of commands, it needs
 that directory to be at the top of your `PATH` environment variable.
 
-During the install process, we install scripts that configures this
+During the install process, we install scripts that configure this
 automatically for you. These scripts are `/etc/profile.d/alt.sh` &
 `/etc/fish/conf.d/alt.fish` (the location of these scripts may vary on some
 platforms).
 
-In some cases, you may need to force these scripts to re-load. You can try the following steps:
+In some cases, you may need to force these scripts to re-load. You can try the
+following steps:
 
 1.  Close & re-open your terminal
 1.  Log out of your desktop session & log back in again

--- a/README.md
+++ b/README.md
@@ -34,47 +34,39 @@ itself in a few ways:
     their dependencies. How you install different versions of commands is
     entirely up to you.
 
-## Installation
+## Install
 
-1.  Install the `alt` binary.
+### Debian / Ubuntu / Anything using DEBs
 
-    ```sh
-    curl -sL https://github.com/dotboris/alt/raw/master/install.sh | bash -s
-    ```
-
-1.  Add the `alt` shims directory to the top of your `PATH`.
-    This lets `alt` change command versions.
-
-    For BASH:
+1.  Open the [latest release page on Github][latest-release]
+1.  Download the `.deb` file matching your architecture
+1.  Install the `.deb` file by double clicking on it
+1.  OR Install the `.deb` file from the command line
 
     ```sh
-    echo 'export PATH="$HOME/.local/alt/shims:$PATH"' >> ~/.bashrc
-    export PATH="$HOME/.local/alt/shims:$PATH"
+    sudo apt install path/to/alt.deb
     ```
 
-    For ZSH:
+Note: You will probably need to log out & log back in to your user for `alt` to
+finish being configured.
 
-    ```sh
-    echo 'export PATH="$HOME/.local/alt/shims:$PATH"' >> ~/.zshrc
-    export PATH="$HOME/.local/alt/shims:$PATH"
-    ```
+### OSX (Homebrew & Linuxbrew)
 
-    For FISH:
+```sh
+brew tap dotboris/alt
+brew install alt-bin
+```
 
-    ```sh
-    echo 'set -x PATH "$HOME/.local/alt/shims" $PATH' >> ~/.config/fish/config.fish
-    set -x PATH "$HOME/.local/alt/shims" $PATH
-    ```
+Pay close attention to the "Caveats" messages as you'll need to add a line to
+your `~/.bashrc` / `~/.zshrc` files.
 
-1.  (Optional) Add `.alt.toml` to your global gitignore file.
+### Pre-packaged binaries
 
-    During it's operation, `alt` puts a file named `.alt.toml` in the current
-    directory. These files don't belong in git repositories. To avoid getting
-    those files all over your git repositories, you can add them to a global
-    gitignore file.
+TODO
 
-    If you don't know how to create a global gitignore file, see:
-    https://help.github.com/articles/ignoring-files/#create-a-global-gitignore
+### From source
+
+TODO
 
 ## Usage
 
@@ -155,6 +147,28 @@ The above command will show you:
 - The versions of those commands available
 - The versions being used in the current directory
 
+## Troubleshooting
+
+### Warning about shims directory not being in `PATH`
+
+TODO: Try logging out / logging back in
+TODO: Try sourcing `/etc/profile.d/alt.sh`
+
+### Git always see a `.alt.toml` file
+
+TODO: Does this belong here or should it be higher up?
+
+During it's normal operation, `alt` puts a file named `.alt.toml` in the current
+directory. __You should not commit `.alt.toml`.__ To avoid getting those files
+all over your git repositories, you can add them to a global gitignore file.
+
+If you don't know how to create a global gitignore file, see:
+https://help.github.com/articles/ignoring-files/#create-a-global-gitignore
+
+```sh
+echo '.alt.toml' >> path/to/your/global-gitgnore
+```
+
 ## Development
 
 ### Setup
@@ -172,3 +186,5 @@ cargo run ...
 ```sh
 cargo test
 ```
+
+[latest-release]: https://github.com/dotboris/alt/releases/latest

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ itself in a few ways:
     sudo apt install path/to/alt.deb
     ```
 
-Note: You will probably need to log out & log back in to your user for `alt` to
-finish being configured.
+You will probably need to log out & log back in to your user for `alt` to finish
+being configured.
 
 ### OSX (Homebrew & Linuxbrew)
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ echo '.alt.toml' >> path/to/your/global-gitgnore
 
 ### Setup
 
-See: https://doc.rust-lang.org/book/second-edition/ch01-01-installation.html
+See: <https://doc.rust-lang.org/book/ch01-01-installation.html>
 
 ### Run
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ itself in a few ways:
     sudo apt install path/to/alt.deb
     ```
 
-You will probably need to log out & log back in to your user for `alt` to finish
-being configured.
+You will probably need to log out & log back in to your desktop session for
+`alt` to be configured.
 
 ### OSX (Homebrew & Linuxbrew)
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ your `~/.bashrc` / `~/.zshrc` files.
 
 ### Pre-packaged binaries
 
-See: [doc/install-prepackaged-bins.md]
+See: [doc/install-pre-packaged-bins.md](./doc/install-pre-packaged-bins.md)
 
 ### From source
 

--- a/README.md
+++ b/README.md
@@ -183,8 +183,9 @@ echo 'set -gx PATH "$HOME/.local/alt/shims" $PATH' >> ~/.config/fish/config.fish
 ### `.alt.toml` file in git repositories
 
 During it's normal operation, `alt` puts a file named `.alt.toml` in the current
-directory. __You should not commit `.alt.toml`.__ To avoid getting those files
-all over your git repositories, you can add them to a global gitignore file.
+directory. __You should not commit `.alt.toml` to git or any other VCS.__ To
+avoid getting those files all over your git repositories, you can add them to a
+global gitignore file.
 
 If you don't know how to create a global gitignore file, see:
 https://help.github.com/articles/ignoring-files/#create-a-global-gitignore

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ See: [doc/install-pre-packaged-bins.md](./doc/install-pre-packaged-bins.md)
 
 ### From source
 
-TODO
+See: [doc/install-from-source.md](./doc/install-from-source.md)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ itself in a few ways:
 ### Debian / Ubuntu / Anything using DEBs
 
 1.  Open the [latest release page on Github][latest-release]
-1.  Download the `.deb` file matching your architecture
+1.  Download the `.deb` file matching your system architecture
 1.  Install the `.deb` file by double clicking on it
 1.  OR Install the `.deb` file from the command line
 
@@ -62,7 +62,7 @@ your `~/.bashrc` / `~/.zshrc` files.
 
 ### Pre-packaged binaries
 
-TODO
+See: [doc/install-prepackaged-bins.md]
 
 ### From source
 

--- a/README.md
+++ b/README.md
@@ -151,12 +151,35 @@ The above command will show you:
 
 ### Warning about shims directory not being in `PATH`
 
-TODO: Try logging out / logging back in
-TODO: Try sourcing `/etc/profile.d/alt.sh`
+Behind the scenes, `alt` manages a directory of "shims"
+(`$HOME/.local/alt/shims`). In order to switch the version of commands, it needs
+that directory to be at the top of your `PATH` environment variable.
 
-### Git always see a `.alt.toml` file
+During the install process, we install scripts that configures this
+automatically for you. These scripts are `/etc/profile.d/alt.sh` &
+`/etc/fish/conf.d/alt.fish` (the location of these scripts may vary on some
+platforms).
 
-TODO: Does this belong here or should it be higher up?
+In some cases, you may need to force these scripts to re-load. You can try the following steps:
+
+1.  Close & re-open your terminal
+1.  Log out of your desktop session & log back in again
+
+If either or both of these fail, you can put the shim directory on top of your
+`PATH` manually. This will vary depending on what shell you use.
+
+```sh
+# For BASH
+echo 'export PATH="$HOME/.local/alt/shims:$PATH"' >> ~/.bashrc
+
+# For ZSH
+echo 'export PATH="$HOME/.local/alt/shims:$PATH"' >> ~/.zshrc
+
+# For FISH
+echo 'set -gx PATH "$HOME/.local/alt/shims" $PATH' >> ~/.config/fish/config.fish
+```
+
+### `.alt.toml` file in git repositories
 
 During it's normal operation, `alt` puts a file named `.alt.toml` in the current
 directory. __You should not commit `.alt.toml`.__ To avoid getting those files

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ echo '.alt.toml' >> path/to/your/global-gitgnore
 
 ### Setup
 
-See: <https://doc.rust-lang.org/book/ch01-01-installation.html>
+See: <https://www.rust-lang.org/tools/install>
 
 ### Run
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,3 +27,5 @@
     ```
 
 1.  Travis CI will build the release and push it to github
+1.  Wait for Travis CI to finish building & pushing the artifacts
+1.  Update the Homebrew formula in <https://github.com/dotboris/homebrew-alt>

--- a/ci/package.py
+++ b/ci/package.py
@@ -47,21 +47,6 @@ def build_deb(rust_target, dest_dir):
     sh('cargo', 'deb', '--target', rust_target, '-o', dest_dir, '--', '--locked')
 
 
-def build_gzip_bin(bin_path, version, rust_target, dest_dir):
-    step('Packinging {0} as a gzipped binary'.format(bin_path))
-    work_dir = mkdtemp()
-
-    to_gzip_file = path.join(work_dir, 'alt')
-    copy(bin_path, to_gzip_file)
-    sh('gzip', '-fk9', to_gzip_file)
-    move(
-        '{}.gz'.format(to_gzip_file),
-        path.join(dest_dir, 'alt_v{0}_{1}.gz'.format(version, rust_target))
-    )
-
-    rmtree(work_dir)
-
-
 def build_tarbal(bin_path, version, rust_target, dest_dir):
     dest_file_name = 'alt_v{0}_{1}.tar.gz'.format(version, rust_target)
     step('Packinging {}'.format(dest_file_name))
@@ -135,8 +120,6 @@ def main(
     print(version)
 
     build_tarbal(alt_bin, version, rust_target, dest_dir)
-
-    build_gzip_bin(alt_bin, version, rust_target, dest_dir)
 
     if is_platform('linux'):
         build_deb(rust_target, dest_dir)

--- a/doc/install-from-source.md
+++ b/doc/install-from-source.md
@@ -1,5 +1,8 @@
 # Install from Source
 
+Note that the following instructions assume a fairly "normal" file system. You
+may need to adjust some of the paths here to match your system.
+
 1.  Open the [latest release page on Github][latest-release]
 1.  Download the source `.tar.gz` file
 1.  Install the Rust compiler

--- a/doc/install-from-source.md
+++ b/doc/install-from-source.md
@@ -1,0 +1,53 @@
+# Install from Source
+
+1.  Open the [latest release page on Github][latest-release]
+1.  Download the source `.tar.gz` file
+1.  Install the Rust compiler
+
+    This can be done through your distributions' package manager. Note that the
+    version of rust packaged by some distributions may be fairly out of date.
+
+    I recommend installing rust with <https://rustup.rs/>.
+
+1.  Extract the source code
+
+    Before you run this, be sure to replace `{version}` to match the file you
+    downloaded.
+
+    ```sh
+    tar xvzf {version}.tar.gz
+    cd alt-{version}
+    ```
+
+1.  Compile `alt` (This will take a while)
+
+    ```sh
+    cargo build --release --locked
+    ```
+
+1.  Install the `alt` binary
+
+    ```sh
+    sudo cp target/release/alt /usr/local/bin/alt
+    ```
+
+1.  Install the `PATH` configuration scripts
+
+    ```sh
+    sudo cp etc/profile.d/alt.sh /etc/profile.d/alt.sh
+    # (Optional) if you use fish
+    sudo cp etc/fish/conf.d/alt.fish /etc/fish/conf.d/alt.fish
+    ```
+
+1.  (Optional) Install the completions
+
+    ```sh
+    # If you use BASH
+    sudo cp target/release/completion/alt.bash /etc/bash_completion.d/alt.bash
+    # If you use ZSH
+    sudo cp target/release/completion/_alt /usr/share/zsh/site-functions/_alt
+    # If you use FISH
+    sudo cp target/release/completion/alt.fish /etc/fish/completions/alt.fish
+    ```
+
+[latest-release]: https://github.com/dotboris/alt/releases/latest

--- a/doc/install-from-source.md
+++ b/doc/install-from-source.md
@@ -4,10 +4,7 @@
 1.  Download the source `.tar.gz` file
 1.  Install the Rust compiler
 
-    This can be done through your distributions' package manager. Note that the
-    version of rust packaged by some distributions may be fairly out of date.
-
-    I recommend installing rust with <https://rustup.rs/>.
+    See: <https://doc.rust-lang.org/book/ch01-01-installation.html>
 
 1.  Extract the source code
 

--- a/doc/install-from-source.md
+++ b/doc/install-from-source.md
@@ -50,4 +50,7 @@
     sudo cp target/release/completion/alt.fish /etc/fish/completions/alt.fish
     ```
 
+You will probably need to log out & log back in to your user so that the `PATH`
+configuration scripts you install will load.
+
 [latest-release]: https://github.com/dotboris/alt/releases/latest

--- a/doc/install-from-source.md
+++ b/doc/install-from-source.md
@@ -47,7 +47,7 @@
     sudo cp target/release/completion/alt.fish /etc/fish/completions/alt.fish
     ```
 
-You will probably need to log out & log back in to your user so that the `PATH`
-configuration scripts you install will load.
+You will probably need to log out & log back in to your desktop session so that
+the `PATH` configuration scripts you installed will load.
 
 [latest-release]: https://github.com/dotboris/alt/releases/latest

--- a/doc/install-from-source.md
+++ b/doc/install-from-source.md
@@ -4,7 +4,7 @@
 1.  Download the source `.tar.gz` file
 1.  Install the Rust compiler
 
-    See: <https://doc.rust-lang.org/book/ch01-01-installation.html>
+    See: <https://www.rust-lang.org/tools/install>
 
 1.  Extract the source code
 

--- a/doc/install-pre-packaged-bins.md
+++ b/doc/install-pre-packaged-bins.md
@@ -4,10 +4,11 @@ Note that the following instructions assume a fairly "normal" file system.
 You may need to adjust some of the paths here to match your system.
 
 1.  Open the [latest release page on Github][latest-release]
-1.  Open the `.tar.gz` file that matches your system architecture
+1.  Download the `.tar.gz` file that matches your system architecture
 1.  Extract the `.tar.gz` file
 
-    Before to replace `{version}` & `{system}` to match the file you downloaded.
+    Before you run this, be sure to replace `{version}` & `{system}` to match
+    the file you downloaded.
 
     ```sh
     tar xvzf alt_{version}_{system}.tar.gz

--- a/doc/install-pre-packaged-bins.md
+++ b/doc/install-pre-packaged-bins.md
@@ -1,6 +1,6 @@
 # Install Pre-packaged Binaries
 
-Note that the following instructions assume a farly "normal" file system setup.
+Note that the following instructions assume a fairly "normal" file system.
 You may need to adjust some of the paths here to match your system.
 
 1.  Open the [latest release page on Github][latest-release]

--- a/doc/install-pre-packaged-bins.md
+++ b/doc/install-pre-packaged-bins.md
@@ -40,7 +40,7 @@ You may need to adjust some of the paths here to match your system.
     sudo cp completion/alt.fish /etc/fish/completions/alt.fish
     ```
 
-You will probably need to log out & log back in to your user so that the `PATH`
-configuration scripts you install will load.
+You will probably need to log out & log back in to your desktop session so that
+the `PATH` configuration scripts you installed will load.
 
 [latest-release]: https://github.com/dotboris/alt/releases/latest

--- a/doc/install-pre-packaged-bins.md
+++ b/doc/install-pre-packaged-bins.md
@@ -1,0 +1,42 @@
+# Install Pre-packaged Binaries
+
+Note that the following instructions assume a farly "normal" file system setup.
+You may need to adjust some of the paths here to match your system.
+
+1.  Open the [latest release page on Github][latest-release]
+1.  Open the `.tar.gz` file that matches your system architecture
+1.  Extract the `.tar.gz` file
+
+    Before to replace `{version}` & `{system}` to match the file you downloaded.
+
+    ```sh
+    tar xvzf alt_{version}_{system}.tar.gz
+    cd alt_{version}_{system}
+    ```
+
+1.  Install the `alt` binary
+
+    ```sh
+    sudo cp bin/alt /usr/local/bin/alt
+    ```
+
+1.  Install the `PATH` configuration scripts
+
+    ```sh
+    sudo cp etc/profile.d/alt.sh /etc/profile.d/alt.sh
+    # (Optional) if you use fish
+    sudo cp etc/fish/conf.d/alt.fish /etc/fish/conf.d/alt.fish
+    ```
+
+1.  (Optional) Install the completions
+
+    ```sh
+    # If you use BASH
+    sudo cp completion/alt.bash /etc/bash_completion.d/alt.bash
+    # If you use ZSH
+    sudo cp completion/_alt /usr/share/zsh/site-functions/_alt
+    # If you use FISH
+    sudo cp completion/alt.fish /etc/fish/completions/alt.fish
+    ```
+
+[latest-release]: https://github.com/dotboris/alt/releases/latest

--- a/doc/install-pre-packaged-bins.md
+++ b/doc/install-pre-packaged-bins.md
@@ -40,4 +40,7 @@ You may need to adjust some of the paths here to match your system.
     sudo cp completion/alt.fish /etc/fish/completions/alt.fish
     ```
 
+You will probably need to log out & log back in to your user so that the `PATH`
+configuration scripts you install will load.
+
 [latest-release]: https://github.com/dotboris/alt/releases/latest

--- a/install.sh
+++ b/install.sh
@@ -1,70 +1,14 @@
 #!/bin/bash
 set -e -o pipefail
 
-get_latest_version() {
-  curl -s --head https://github.com/dotboris/alt/releases/latest \
-  | grep '^Location' \
-  | grep -Eo 'v[0-9]+(\.[0-9]+)+'
-}
+# We are leaving this script in place so that old guides / documentation will
+# point users to the new ways of installing alt. This is a much better
+# alternative than having users get a 404 and passing that to bash so that it
+# gets evaluated.
 
-get_std_arch() {
-  local _arch
-  _arch="$(uname -m)"
+echo '👋 Hi there!'
+echo 'alt no longer supports this installation method'
+echo 'For alternate installation instructions, please see:'
+echo '  https://github.com/dotboris/alt#install'
 
-  case "$_arch" in
-    i386|i686) printf 'i686';;
-    *) printf '%s' "$_arch";;
-  esac
-}
-
-get_target() {
-  local _arch
-  _arch="$(get_std_arch)"
-  local _os
-  _os="$(uname -s | tr '[:upper:]' '[:lower:]')"
-
-  case "$_os-$_arch" in
-    linux-x86_64) printf 'x86_64-unknown-linux-musl';;
-    darwin-x86_64) printf 'x86_64-apple-darwin';;
-    *)
-      echo "Unsupported OS/Arch $_os/$_arch. Try building from source."
-      return 1
-      ;;
-  esac
-}
-
-version="$(get_latest_version)"
-target="$(get_target)"
-
-echo "Installing alt $version for $target as /usr/local/bin/alt"
-echo "You may be prompted for your password"
-
-file_name="alt_${version}_${target}.gz"
-url="https://github.com/dotboris/alt/releases/download/$version/$file_name"
-
-sudo bash -e -o pipefail -s <<SH
-  curl --progress-bar -L "$url" -o /usr/local/bin/alt.gz
-  rm -f /usr/local/bin/alt
-  gzip -d /usr/local/bin/alt.gz
-  rm -f /usr/local/bin/alt.gz
-  chmod +x /usr/local/bin/alt
-SH
-
-echo
-echo '  🎉  Alt is installed!  🎉'
-echo
-echo 'Remember to add $HOME/.local/alt/shims to your PATH'
-echo
-echo 'BASH:'
-echo $'    echo \'export PATH="$HOME/.local/alt/shims:$PATH"\' >> ~/.bashrc'
-echo $'    export PATH="$HOME/.local/alt/shims:$PATH"'
-echo
-echo 'ZSH:'
-echo $'    echo \'export PATH="$HOME/.local/alt/shims:$PATH"\' >> ~/.zshrc'
-echo $'    export PATH="$HOME/.local/alt/shims:$PATH"'
-echo
-echo 'FISH:'
-echo $'    echo \'set -x PATH "$HOME/.local/alt/shims" $PATH\' >> ~/.config/fish/config.fish'
-echo $'    set -x PATH "$HOME/.local/alt/shims" $PATH'
-echo
-
+exit 1

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -47,7 +47,7 @@ You are seeing this warning because the shim directory ({shim_dir}) is not in \
 your {path_env_var} environment variable.
 
 Normally, alt should configure this automatically during the install process.
-In come cases you may need to:
+In some cases you may need to:
 
 - {reopen_terminal}
 - {relogin}

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -43,7 +43,7 @@ pub fn check_shim_in_path() {
 {warning_line}
 Alt is not configured correctly and will not work!
 
-You are seeing the warning because the shim directory ({shim_dir}) is not in \
+You are seeing this warning because the shim directory ({shim_dir}) is not in \
 your {path_env_var} environment variable.
 
 Normally, alt should configure this automatically during the install process.

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -41,7 +41,7 @@ pub fn check_shim_in_path() {
         eprintln!(
             "\
 {warning_line}
-Alt is not configured corrected and will not work!
+Alt is not configured correctly and will not work!
 
 You are seeing the warning because the shim directory ({shim_dir}) is not in \
 your {path_env_var} environment variable.

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -26,7 +26,7 @@ fn line_label(width: usize, label: &str) -> String {
 }
 
 pub fn check_shim_in_path() {
-    let path = env::var("PATH").unwrap();
+    let path = env::var("PATH").unwrap_or_default();
     let mut parts = env::split_paths(&path);
 
     let shim_dir = config::shim_dir();
@@ -38,22 +38,32 @@ pub fn check_shim_in_path() {
         let shim_dir = style(shim_dir).cyan();
         let path_env_var = style("PATH").cyan();
 
-        eprintln!("{}", line_label(term_width as usize, "WARNING"));
-        eprintln!("Alt is not installed corrected and will not work!");
-        eprintln!();
         eprintln!(
-            "You are seeing the warning because the shim directory ({}) is not in your {} environment variable.",
-            shim_dir,
-            path_env_var
+            "\
+{warning_line}
+Alt is not configured corrected and will not work!
+
+You are seeing the warning because the shim directory ({shim_dir}) is not in \
+your {path_env_var} environment variable.
+
+Normally, alt should configure this automatically during the install process.
+In come cases you may need to:
+
+- {reopen_terminal}
+- {relogin}
+
+If the problem persists, please see:
+    {troubleshooting_link}
+{bottom_line}
+
+",
+            warning_line=line_label(term_width as usize, "WARNING"),
+            bottom_line=line(term_width as usize),
+            shim_dir=shim_dir,
+            path_env_var=path_env_var,
+            reopen_terminal=style("re-open your terminal").bold(),
+            relogin=style("log out and log back into your user session").bold(),
+            troubleshooting_link=style("https://github.com/dotboris/alt#troubleshooting").cyan()
         );
-        eprintln!();
-        eprintln!("Please add {} to your {} environment variable.", shim_dir, path_env_var);
-        eprintln!();
-        eprintln!(
-            "Alternatively, see {} for setup instructions.",
-            style("https://github.com/dotboris/alt#installation").cyan()
-        );
-        eprintln!("{}", line(term_width as usize));
-        eprintln!();
     }
 }


### PR DESCRIPTION
Related to #42 & #41 