### PR TITLE
Ensure that shims are really close to the top of the PATH in fish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+### Changed
+
+- Move the shims directory higher up in the `PATH` on fish by using
+  `fish_user_paths`

--- a/etc/fish/conf.d/alt.fish
+++ b/etc/fish/conf.d/alt.fish
@@ -1,1 +1,1 @@
-set -gx PATH "$HOME/.local/alt/shims" $PATH
+set -g fish_user_paths "$HOME/.local/alt/shims" $fish_user_paths


### PR DESCRIPTION
Fish has a variable named `fish_user_paths` that is prepended to the path. Users are expected to put their own additions to the path in there.

Previously, we put the shims on top of `PATH`. But because of `fish_user_paths` we can get screwed.

This change makes it so that we can't get screwed by this.