### PR TITLE
Avoid setting `fish_user_paths` with `-g` in order to avoid getting warnings about shadowed vars touching `fish_user_paths` in other contexts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,8 +9,5 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.yml]
-indent_size = 2
-
-[*.sh]
+[{*.sh,*.yml,*fish}]
 indent_size = 2

--- a/etc/fish/conf.d/alt.fish
+++ b/etc/fish/conf.d/alt.fish
@@ -1,1 +1,10 @@
-set -g fish_user_paths "$HOME/.local/alt/shims" $fish_user_paths
+set -l shims_dir "$HOME/.local/alt/shims"
+
+if test "$fish_user_paths[1]" != "$shims_dir"
+  # Remove all other instances of the shims dir in the PATH
+  while set -l shims_dir_pos (contains -i -- "$shims_dir" $fish_user_paths)
+    set -e "fish_user_paths[$shims_dir_pos]"
+  end
+
+  set -U fish_user_paths "$shims_dir" $fish_user_paths
+end


### PR DESCRIPTION
The previous version of this script would write to `fish_user_paths` using `set -g`. This had the advantage of being simple.  Since variables set with `set -g` are not persisted, we don't need to worry about the pervious state and we can always do this in our script.

The problem with this approach is that the `set -g` version of `fish_user_paths` shadows the universal version that exists.

When users try to add to their own path with

```sh
set -U fish_user_paths "/path/to/something/bin" $fish_user_paths
```

They get a warning about shadowing and their path is not affected at all. This breaks normal fish behaviour which is unacceptable.

With this change, we don't create a global version of `fish_user_paths` and we only use the universal one. Because that var is persisted, we have to do some funny business to figure out if we need to clean things up or move ourselves up the PATH.