### PR TITLE
Remove `--version` on subcommands and document how to pass `--help` to executed command with `alt exec`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Document how to pass flags parsed by `alt exec` to the executed command
+  instead of `alt exec` itself. This was done directly in `alt exec`'s help
+  text.
+
 ### Removed
 
 - Removed the `--version` & `-V` flags from all subcommands. This means that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Removed the `--version` & `-V` flags from all subcommands. This means that
+- Remove the `--version` & `-V` flags from all subcommands. This means that
   `alt --version` works just fine but `alt scan --version` does not. This was
   done because the `--version` flag on subcommands did not output anything
   useful.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Removed
+
+- Removed the `--version` & `-V` flags from all subcommands. This means that
+  `alt --version` works just fine but `alt scan --version` does not. This was
+  done because the `--version` flag on subcommands did not output anything
+  useful.
+
 ### Changed
 
 - Reduce final binary size by removing unused unicode regex features.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,6 +5,10 @@ pub fn make_app() -> App<'static, 'static> {
     clap_app!(alt =>
         (version: crate_version!())
         (about: "Switch between different versions of commands")
+        (settings: &[
+            AppSettings::SubcommandRequiredElseHelp,
+            AppSettings::VersionlessSubcommands
+        ])
         (@subcommand exec =>
             (about: "Run the given command")
             (after_help:
@@ -54,8 +58,4 @@ pub fn make_app() -> App<'static, 'static> {
             (@arg bin: +required "Path to the executable for the version")
         )
     )
-        .settings(&[
-            AppSettings::SubcommandRequiredElseHelp,
-            AppSettings::VersionlessSubcommands
-        ])
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,6 +7,18 @@ pub fn make_app() -> App<'static, 'static> {
         (about: "Switch between different versions of commands")
         (@subcommand exec =>
             (about: "Run the given command")
+            (after_help:
+"ARGS NOTE:
+    Note that `alt exec` handles some flags on its own (`--help` for example).
+    If you want to pass such arguments to the executed command instead of
+    `alt exec`, you will need to use `--` to tell alt exec to stop parsing
+    arguments.
+
+    Example:
+
+    alt exec node --help        # --help passed to alt (shows this message)
+    alt exec node -- --help     # --help passed to node (shows node's help)"
+            )
             (@arg command: +required "The command to run")
             (@arg command_args: ... "Arguments to pass to the command")
         )

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -42,5 +42,8 @@ pub fn make_app() -> App<'static, 'static> {
             (@arg bin: +required "Path to the executable for the version")
         )
     )
-        .setting(AppSettings::SubcommandRequiredElseHelp)
+        .settings(&[
+            AppSettings::SubcommandRequiredElseHelp,
+            AppSettings::VersionlessSubcommands
+        ])
 }


### PR DESCRIPTION
Closes #4 

This doesn't really fix #4 but rather makes it obvious how someone should use `alt exec` with special flags handled by `alt`.

I think that this solution is pretty clean since it allows us to show help for the `alt exec` command while letting users know what they should do if they want to pass that flag to the executed command.