### PR TITLE
Display verbose error details when alt fails to exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Display relevant debugging information when `alt` fails to execute a command.
+  This applies for both the `alt exec` command as well as executing commands
+  through shims (the usual way of running commands through `alt`). This should
+  help people figure out what's going on when `alt` fails. Note that previously
+  `alt` only displayed the generic underlying error.
+
 ## v1.1.1 - 2019-11-16
 
 ### Added

--- a/src/exec_cmd.rs
+++ b/src/exec_cmd.rs
@@ -30,7 +30,7 @@ pub fn run(command: &str, command_args: &[String]) {
 
             let pretty_command_version = command_version
                 .as_deref()
-                .unwrap_or("(system)");
+                .unwrap_or("(not set, falling back on system version)");
 
             // Since we're calling exec, either our process will be replaced
             // (and this code will never be called) or something's wrong and

--- a/src/exec_cmd.rs
+++ b/src/exec_cmd.rs
@@ -3,12 +3,14 @@ use crate::command;
 use std::os::unix::process::CommandExt;
 use std::process;
 use std::process::Command;
+use std::env;
 
 pub fn run(command: &str, command_args: &[String]) {
     let defs = def_file::load();
     let command_version = command::find_selected_version(&command);
 
     let bin = command_version
+        .clone()
         .map(|version| {
             def_file::find_bin(&defs, command, &version)
                 .unwrap_or_else(|| panic!(
@@ -26,11 +28,20 @@ pub fn run(command: &str, command_args: &[String]) {
                 .args(command_args)
                 .exec();
 
-            // Since we're callling exec, either our process will be replaced
+            // Since we're calling exec, either our process will be replaced
             // (and this code will never be called) or something's wrong and
             // we get this error
-            eprintln!("Failed to exec()!");
-            eprintln!("{:#?}", err);
+            eprintln!("🔥 alt failed to run {}!", command);
+            eprintln!("error: {:?}", err);
+            eprintln!("command: {}", command);
+            eprintln!("command version: {}",
+                command_version
+                    .as_deref()
+                    .unwrap_or("(using system version)")
+            );
+            eprintln!("args: {:?}", command_args);
+            eprintln!("bin: {}", bin.display());
+            eprintln!("current dir: {:?}", env::current_dir());
             panic!();
         },
         None => {

--- a/src/exec_cmd.rs
+++ b/src/exec_cmd.rs
@@ -28,17 +28,19 @@ pub fn run(command: &str, command_args: &[String]) {
                 .args(command_args)
                 .exec();
 
+            let pretty_command_version = command_version
+                .as_deref()
+                .unwrap_or("(system)");
+
             // Since we're calling exec, either our process will be replaced
             // (and this code will never be called) or something's wrong and
             // we get this error
-            eprintln!("🔥 alt failed to run {}!", command);
+            eprintln!("🔥 alt failed to run {} version {}!",
+                command, pretty_command_version
+            );
             eprintln!("error: {:?}", err);
             eprintln!("command: {}", command);
-            eprintln!("command version: {}",
-                command_version
-                    .as_deref()
-                    .unwrap_or("(using system version)")
-            );
+            eprintln!("command version: {}", pretty_command_version);
             eprintln!("args: {:?}", command_args);
             eprintln!("bin: {}", bin.display());
             eprintln!("current dir: {:?}", env::current_dir());


### PR DESCRIPTION
Every once in a while `alt` will fail to exec a command on my end. Sometimes it's because the command defined in alt no longer exists on my system and other times it's because of some other strange fluke. With the current error display setup, it's really hard to figure out why this failed.

I've added detailed information to the crash so that users can figure out what `alt` was trying to run and why it failed.