### PR TITLE
Add `alt doctor` command that can fix known / common issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added `alt doctor` command that can find and detect certain common problems
+  with `alt` and sometimes automatically fix them. This first version of `alt
+  doctor` currently only knowns how to find and fix broken command version
+  definitions.
+
 ### Changed
 
 - Display relevant debugging information when `alt` fails to execute a command.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,7 @@ dependencies = [
  "escargot",
  "glob",
  "lazy_static",
+ "predicates",
  "rand",
  "regex",
  "toml",
@@ -56,6 +57,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "autocfg"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "bitflags"
@@ -153,6 +160,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,6 +219,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,12 +241,15 @@ checksum = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
 
 [[package]]
 name = "predicates"
-version = "1.0.1"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e09015b0d3f5a0ec2d4428f7559bb7b3fff341b4e159fedd1d57fac8b939ff"
+checksum = "96bfead12e90dccead362d62bb2c90a5f6fc4584963645bc7f71a735e0b0735a"
 dependencies = [
  "difference",
+ "float-cmp",
+ "normalize-line-endings",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ features = ["std", "perf", "unicode-perl"]
 [dev-dependencies]
 assert_cmd = "1.0"
 escargot = "0.5"
+predicates = "1.0.5"
 rand = "0.7"
 
 [build-dependencies]

--- a/README.md
+++ b/README.md
@@ -152,6 +152,21 @@ The above command will show you:
 
 ## Troubleshooting
 
+If you are experiencing issues with `alt`, you should try running `alt`'s
+built-in self-healing command:
+
+```sh
+alt doctor
+```
+
+This command will look for problems, report them to you and, in some cases,
+propose an automatic fix.
+
+If `alt doctor` is not able to find or fix your problem, you can try looking at
+the sections below. If that doesn't help, feel free to [open an
+issue](https://github.com/dotboris/alt/issues/new). We'll be happy to help you
+out.
+
 ### Warning about shims directory not being in `PATH`
 
 Behind the scenes, `alt` manages a directory of "shims"

--- a/fixtures/commands/alfa1
+++ b/fixtures/commands/alfa1
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo 'alfa1'

--- a/fixtures/commands/alfa2
+++ b/fixtures/commands/alfa2
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo 'alfa2'

--- a/fixtures/commands/alfa3
+++ b/fixtures/commands/alfa3
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo 'alfa3'

--- a/fixtures/commands/bravo1
+++ b/fixtures/commands/bravo1
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo 'bravo1'

--- a/fixtures/commands/bravo2
+++ b/fixtures/commands/bravo2
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo 'bravo2'

--- a/fixtures/commands/bravo3
+++ b/fixtures/commands/bravo3
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo 'bravo3'

--- a/fixtures/commands/charlie1
+++ b/fixtures/commands/charlie1
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo 'charlie1'

--- a/fixtures/commands/charlie2
+++ b/fixtures/commands/charlie2
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo 'charlie2'

--- a/fixtures/commands/charlie3
+++ b/fixtures/commands/charlie3
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo 'charlie3'

--- a/fixtures/system_commands/alfa
+++ b/fixtures/system_commands/alfa
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo 'alfa system'

--- a/fixtures/system_commands/bravo
+++ b/fixtures/system_commands/bravo
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo 'bravo system'

--- a/fixtures/system_commands/charlie
+++ b/fixtures/system_commands/charlie
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo 'charlie system'

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -1,7 +1,6 @@
 use crate::config;
 use std::env;
 use std::iter;
-use console;
 use console::style;
 
 fn line(width: usize) -> String {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,73 +1,105 @@
-use clap::App;
-use clap::AppSettings;
+use clap::{ App, AppSettings, SubCommand, Arg };
 
 pub fn make_app() -> App<'static, 'static> {
-    clap_app!(alt =>
-        (version: crate_version!())
-        (about: "Switch between different versions of commands")
-        (settings: &[
+    return App::new("alt")
+        .version(crate_version!())
+        .about("Switch between different versions of commands")
+        .settings(&[
             AppSettings::SubcommandRequiredElseHelp,
             AppSettings::VersionlessSubcommands
         ])
-        (@subcommand exec =>
-            (about: "Run the given command")
-            (after_help:
+
+        .subcommand(SubCommand::with_name("exec")
+            .about("Run the given command")
+            .after_help(
 "ARGS NOTE:
-    Note that `alt exec` handles some flags on its own (`--help` for example).
-    If you want to pass such arguments to the executed command instead of
-    `alt exec`, you will need to use `--` to tell alt exec to stop parsing
-    arguments.
+Note that `alt exec` handles some flags on its own (`--help` for example).
+If you want to pass such arguments to the executed command instead of
+`alt exec`, you will need to use `--` to tell alt exec to stop parsing
+arguments.
 
-    Example:
+Example:
 
-    alt exec node --help        # --help passed to alt (shows this message)
-    alt exec node -- --help     # --help passed to node (shows node's help)"
+alt exec node --help        # --help passed to alt (shows this message)
+alt exec node -- --help     # --help passed to node (shows node's help)"
             )
-            (@arg command: +required "The command to run")
-            (@arg command_args: ... "Arguments to pass to the command")
+            .arg(Arg::with_name("command")
+                .help("The command to run")
+                .required(true)
+            )
+            .arg(Arg::with_name("command_args")
+                .help("Arguments to pass to the command")
+                .multiple(true),
+            )
         )
-        (@subcommand shim =>
-            (about: "Generate shims for all managed commands")
+
+        .subcommand(SubCommand::with_name("shim")
+            .about("Generate shims for all managed commands")
         )
-        (@subcommand which =>
-            (about: "Print the resolved path of a command")
-            (@arg command: +required "Command to look up")
+
+        .subcommand(SubCommand::with_name("which")
+            .about("Print the resolved path of a command")
+            .arg(Arg::with_name("command")
+                .required(true)
+                .help("Command to look up")
+            )
         )
-        (@subcommand scan =>
-            (about: "Scan for different versions of the given command")
-            (@arg command: +required "Command to scan for")
+
+        .subcommand(SubCommand::with_name("scan")
+            .about("Scan for different versions of the given command")
+            .arg(Arg::with_name("command")
+                .required(true)
+                .help("Command to scan for")
+            )
         )
-        (@subcommand use =>
-            (about: "Swtich the version of a command")
-            (after_help:
+
+        .subcommand(SubCommand::with_name("use")
+            .about("Swtich the version of a command")
+            .after_help(
 "EXAMPLES:
     alt use node 8        Use version 8 of node
     alt use node          Prompt for a version of node to use
     alt use node system   Use the system version of node"
             )
-            (@arg command: +required "Command to switch the version of")
-            (@arg version: "Version to use (optional)")
-        )
-        (@subcommand show =>
-            (about: "Print commands and their versions")
-        )
-        (@subcommand doctor =>
-            (about: "Checks if alt is setup correctly. Helps debug problems.")
-            (@arg fix_mode:
-                // TODO: use a dash instead of an underscore
-                --fix_mode -f
-                +required
-                +takes_value
-                possible_value[auto never prompt]
-                default_value[prompt]
-                "Control how automatic fixes are applied."
+            .arg(Arg::with_name("command")
+                .required(true)
+                .help("Command to switch the version of")
+            )
+            .arg(Arg::with_name("version")
+                .help("Version to use (optional)")
             )
         )
-        (@subcommand def =>
-            (about: "Define a new version")
-            (@arg command: +required "Command to define the version for")
-            (@arg version: +required "The name of the version")
-            (@arg bin: +required "Path to the executable for the version")
+
+        .subcommand(SubCommand::with_name("show")
+            .about("Print commands and their versions")
         )
-    )
+
+        .subcommand(SubCommand::with_name("def")
+            .about("Define a new version")
+            .arg(Arg::with_name("command")
+                .required(true)
+                .help("Command to define the version for")
+            )
+            .arg(Arg::with_name("version")
+                .required(true)
+                .help("The name of the version")
+            )
+            .arg(Arg::with_name("bin")
+                .required(true)
+                .help("Path to the executable for the version")
+            )
+        )
+
+        .subcommand(SubCommand::with_name("doctor")
+            .about("Checks if alt is setup correctly. Helps debug problems.")
+            .arg(Arg::with_name("fix_mode")
+                .short("f")
+                .long("fix-mode")
+                .takes_value(true)
+                .possible_values(&["auto", "never", "prompt"])
+                .default_value("prompt")
+                .help("Control how automatic fixes are applied.")
+            )
+        )
+        ;
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -53,7 +53,15 @@ pub fn make_app() -> App<'static, 'static> {
         )
         (@subcommand doctor =>
             (about: "Checks if alt is setup correctly. Helps debug problems.")
-            (@arg fix: --fix -f "Attempts to automatically fix issues")
+            (@arg fix_mode:
+                // TODO: use a dash instead of an underscore
+                --fix_mode -f
+                +required
+                +takes_value
+                possible_value[auto never prompt]
+                default_value[prompt]
+                "Control how automatic fixes are applied."
+            )
         )
         (@subcommand def =>
             (about: "Define a new version")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -51,6 +51,10 @@ pub fn make_app() -> App<'static, 'static> {
         (@subcommand show =>
             (about: "Print commands and their versions")
         )
+        (@subcommand doctor =>
+            (about: "Checks if alt is setup correctly. Helps debug problems.")
+            (@arg fix: --fix -f "Attempts to automatically fix issues")
+        )
         (@subcommand def =>
             (about: "Define a new version")
             (@arg command: +required "Command to define the version for")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,15 +13,15 @@ pub fn make_app() -> App<'static, 'static> {
             .about("Run the given command")
             .after_help(
 "ARGS NOTE:
-Note that `alt exec` handles some flags on its own (`--help` for example).
-If you want to pass such arguments to the executed command instead of
-`alt exec`, you will need to use `--` to tell alt exec to stop parsing
-arguments.
+    Note that `alt exec` handles some flags on its own (`--help` for example).
+    If you want to pass such arguments to the executed command instead of
+    `alt exec`, you will need to use `--` to tell alt exec to stop parsing
+    arguments.
 
-Example:
+    Example:
 
-alt exec node --help        # --help passed to alt (shows this message)
-alt exec node -- --help     # --help passed to node (shows node's help)"
+    alt exec node --help        # --help passed to alt (shows this message)
+    alt exec node -- --help     # --help passed to node (shows node's help)"
             )
             .arg(Arg::with_name("command")
                 .help("The command to run")

--- a/src/def_file.rs
+++ b/src/def_file.rs
@@ -34,6 +34,14 @@ pub fn find_bin<'a>(defs: &'a CommandDefs, command: &str, version: &str) -> Opti
     defs.get(command).and_then(|def| def.get(version))
 }
 
+pub fn remove_version(defs: &mut CommandDefs, command: &str, version: &str) {
+    let versions = defs.get_mut(command).unwrap();
+    versions.remove(version);
+    if versions.is_empty() {
+        defs.remove(command);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/doctor_cmd.rs
+++ b/src/doctor_cmd.rs
@@ -1,4 +1,5 @@
 use crate::def_file;
+use crate::def_file::CommandDefs;
 use std::collections::HashSet;
 use std::path::Path;
 use std::process;
@@ -13,67 +14,25 @@ pub fn run(fix: bool) {
     );
     println!();
 
-    let mut problem_count = 0;
-    let mut fixable_count = 0;
-    let mut fixed_count = 0;
+    let mut problem_count: u32 = 0;
+    let mut fixable_count: u32 = 0;
+    let mut fixed_count: u32 = 0;
 
-    let defs = def_file::load();
-
-    if defs.is_empty() {
-        problem_count += 1;
-        print_problem(
-            "No commands or command versions are defined. This is normal if \
-            you've just installed alt. You will need to define some commands \
-            & command versions in order to use alt. See: \
-            https://github.com/dotboris/alt#define-command-versions"
-        );
-        println!();
-    }
-
-    let mut defs_to_remove = HashSet::new();
-    for (command, versions) in defs {
-        for (version, bin) in versions {
-            let has_problem = def_has_problem(&command, &version, &bin);
-            if has_problem {
-                problem_count += 1;
-
-                defs_to_remove.insert(
-                    (command.to_string(), version.to_string())
-                );
-
-                if fix {
-                    fixed_count += 1;
-                    print_fixed(&format!(
-                        "Removed entry for {} version {}.",
-                        command, version
-                    ));
-                } else {
-                    fixable_count += 1;
-                    print_fixable(&format!(
-                        "Would remove entry for {} version {}.",
-                        command, version
-                    ));
-                }
-                println!();
-            }
-        }
-    }
+    let CheckDefsRes { defs, removed_defs } = check_defs(
+        fix,
+        &mut problem_count,
+        &mut fixable_count,
+        &mut fixed_count
+    );
 
     if fix {
-        let mut defs = def_file::load();
-        for (command, version) in defs_to_remove {
-            let versions = defs.get_mut(&command).unwrap();
-            versions.remove(&version);
-            if versions.is_empty() {
-                defs.remove(&command);
-            }
-        }
         def_file::save(&defs)
-            .expect("failed to write command versions definition");
+            .expect("failed to write command version definitions");
     }
 
     // TODO: check all used versions point to real versions
     // TODO: check that shims are defined
+    // TODO: check that old shims are not left over
 
     if problem_count > 0 {
         if fix {
@@ -98,8 +57,7 @@ pub fn run(fix: bool) {
             }
         }
 
-        let problems_left = 0.max(problem_count - fixed_count);
-        if problems_left > 1 {
+        if problem_count > fixed_count {
             process::exit(1);
         }
     } else {
@@ -110,6 +68,75 @@ pub fn run(fix: bool) {
         );
     }
 }
+
+struct CheckDefsRes {
+    defs: CommandDefs,
+    removed_defs: HashSet<(String, String)>
+}
+fn check_defs(
+    fix: bool,
+    problem_count: &mut u32,
+    fixable_count: &mut u32,
+    fixed_count: &mut u32
+) -> CheckDefsRes {
+    let defs = def_file::load();
+
+    if defs.is_empty() {
+        *problem_count += 1;
+        print_problem(
+            "No commands or command versions are defined. This is normal if \
+            you've just installed alt. You will need to define some commands \
+            & command versions in order to use alt. See: \
+            https://github.com/dotboris/alt#define-command-versions"
+        );
+        println!();
+    }
+
+    let mut defs_to_remove = HashSet::new();
+
+    for (command, versions) in defs {
+        for (version, bin) in versions {
+            let has_problem = def_has_problem(&command, &version, &bin);
+            if has_problem {
+                *problem_count += 1;
+
+                defs_to_remove.insert(
+                    (command.to_string(), version.to_string())
+                );
+
+                if fix {
+                    *fixed_count += 1;
+                    print_fixed(&format!(
+                        "Removed entry for {} version {}.",
+                        command, version
+                    ));
+                } else {
+                    *fixable_count += 1;
+                    print_fixable(&format!(
+                        "Would remove entry for {} version {}.",
+                        command, version
+                    ));
+                }
+                println!();
+            }
+        }
+    }
+
+    let mut defs = def_file::load();
+    for (command, version) in defs_to_remove.clone() {
+        let versions = defs.get_mut(&command).unwrap();
+        versions.remove(&version);
+        if versions.is_empty() {
+            defs.remove(&command);
+        }
+    }
+
+    return CheckDefsRes {
+        defs,
+        removed_defs: defs_to_remove
+    }
+}
+
 
 fn def_has_problem(command: &str, version: &str, bin: &Path) -> bool {
     if !bin.exists() {

--- a/src/doctor_cmd.rs
+++ b/src/doctor_cmd.rs
@@ -12,17 +12,6 @@ pub fn run(fix_mode: FixMode) {
     let defs = def_file::load();
     let mut fixed_defs = defs.clone();
 
-    if defs.is_empty() {
-        problem_count += 1;
-        print_problem(
-            "No commands or command versions are defined. This is normal if \
-            you've just installed alt. You will need to define some commands \
-            & command versions in order to use alt. See: \
-            https://github.com/dotboris/alt#define-command-versions"
-        );
-        println!();
-    }
-
     for (command, versions) in defs {
         for (version, bin) in versions {
             let has_problem = {
@@ -77,6 +66,18 @@ pub fn run(fix_mode: FixMode) {
             }
         }
     }
+
+    if fixed_defs.is_empty() {
+        problem_count += 1;
+        print_problem(
+            "No commands or command versions are defined. This is normal if \
+            you've just installed alt. You will need to define some commands \
+            & command versions in order to use alt. See: \
+            https://github.com/dotboris/alt#define-command-versions"
+        );
+        println!();
+    }
+
 
     // TODO: check all used versions point to real versions
     // TODO: check that shims are defined

--- a/src/doctor_cmd.rs
+++ b/src/doctor_cmd.rs
@@ -1,7 +1,6 @@
 use crate::def_file;
 use std::process;
 use std::os::unix::fs::MetadataExt;
-use console;
 use dialoguer::Confirm;
 
 pub enum FixMode { Auto, Never, Prompt }

--- a/src/doctor_cmd.rs
+++ b/src/doctor_cmd.rs
@@ -1,0 +1,131 @@
+use crate::def_file;
+use std::path::Path;
+use console;
+
+pub fn run(fix: bool) {
+    println!(
+        "This command (alt doctor) will check for common / known problems and \
+        will give some advice on how to fix them. Note that not all problems \
+        are critical or require fixing. alt can still work perfectly fine \
+        even with some problems."
+    );
+    println!();
+
+    let mut problem_count = 0;
+    let mut fixable_count = 0;
+    let mut fixed_count = 0;
+
+    let defs = def_file::load();
+
+    if defs.is_empty() {
+        problem_count += 1;
+        print_problem(
+            "No commands or command versions are defined. This is normal if \
+            you've just installed alt. You will need to define some commands \
+            & command versions in order to use alt. See: \
+            https://github.com/dotboris/alt#define-command-versions"
+        );
+        println!();
+    }
+
+    for (command, versions) in defs {
+        for (version, bin) in versions {
+            let has_problem = def_has_problem(&command, &version, &bin);
+            if has_problem {
+                problem_count += 1;
+                if fix {
+                    fixed_count += 1;
+                    // TODO: fix
+                    print_fixed(&format!(
+                        "Removed entry for {} version {}.",
+                        command, version
+                    ));
+                } else {
+                    fixable_count += 1;
+                    print_fixable(&format!(
+                        "Would remove entry for {} version {}.",
+                        command, version
+                    ));
+                }
+                println!();
+            }
+        }
+    }
+
+    // TODO: check all defs point to real files
+    // TODO: check all used versions point to real versions
+    // TODO: check that shims are defined
+
+    if problem_count > 0 {
+        if fix {
+            println!(
+                "Found {} problems. {} were automatically fixed.",
+                problem_count,
+                fixed_count
+            );
+        } else {
+            if fixable_count > 0 {
+                println!(
+                    "Found {} problems. {} can automatically be fixed. \
+                    Run alt doctor --fix to automatically fix these problems.",
+                    problem_count,
+                    fixable_count
+                );
+            } else {
+                println!(
+                    "Found {} problems. None can be automatically fixed.",
+                    problem_count
+                );
+            }
+        }
+    } else {
+        println!(
+            "Found no problems. Everything should be fine. If you're still \
+            experiencing issues, please file an issue: \
+            https://github.com/dotboris/alt/issues/new"
+        );
+    }
+}
+
+fn def_has_problem(command: &str, version: &str, bin: &Path) -> bool {
+    if !bin.exists() {
+        print_problem(&format!(
+            "Binary for {} version {} ({}) does not exist.",
+            command, version, bin.display()
+        ));
+        return true;
+    }
+
+    if !bin.is_file() {
+        print_problem(&format!(
+            "Binary for {} version {} ({}) is not a file.",
+            command, version, bin.display()
+        ));
+        return true;
+    }
+
+    // TODO: check permissions (readable + executable)
+
+    return false;
+}
+
+fn print_problem(message: &str) {
+    println!("{}: {}",
+        console::style("Problem").bold().yellow(),
+        message
+    );
+}
+
+fn print_fixable(message: &str) {
+    println!("{}: {}",
+        console::style("Auto-Fixable").bold().cyan(),
+        message
+    );
+}
+
+fn print_fixed(message: &str) {
+    println!("{}: {}",
+        console::style("Fixed").bold().green(),
+        message
+    );
+}

--- a/src/doctor_cmd.rs
+++ b/src/doctor_cmd.rs
@@ -117,7 +117,11 @@ fn should_fix(fix_mode: &FixMode) -> bool {
             Confirm::new()
                 .with_prompt("Would you like to apply this fix?")
                 .interact()
-                .unwrap_or(false)
+                .expect(
+                    "Failed to prompt for fix action. \
+                    If you're trying to use this command non-interactively, \
+                    try passing in --fix-mod <auto|never>"
+                )
         },
     }
 }

--- a/src/doctor_cmd.rs
+++ b/src/doctor_cmd.rs
@@ -1,88 +1,18 @@
 use crate::def_file;
-use crate::def_file::CommandDefs;
-use std::collections::HashSet;
-use std::path::Path;
 use std::process;
 use console;
 
-pub fn run(fix: bool) {
-    println!(
-        "This command (alt doctor) will check for common / known problems and \
-        will give some advice on how to fix them. Note that not all problems \
-        are critical or require fixing. alt can still work perfectly fine \
-        even with some problems."
-    );
-    println!();
+pub enum FixMode { Auto, Never, Prompt }
 
+pub fn run(fix_mode: FixMode) {
     let mut problem_count: u32 = 0;
-    let mut fixable_count: u32 = 0;
     let mut fixed_count: u32 = 0;
 
-    let CheckDefsRes { defs, removed_defs } = check_defs(
-        fix,
-        &mut problem_count,
-        &mut fixable_count,
-        &mut fixed_count
-    );
-
-    if fix {
-        def_file::save(&defs)
-            .expect("failed to write command version definitions");
-    }
-
-    // TODO: check all used versions point to real versions
-    // TODO: check that shims are defined
-    // TODO: check that old shims are not left over
-
-    if problem_count > 0 {
-        if fix {
-            println!(
-                "Found {} problems. {} were automatically fixed.",
-                problem_count,
-                fixed_count
-            );
-        } else {
-            if fixable_count > 0 {
-                println!(
-                    "Found {} problems. {} can automatically be fixed. \
-                    Run alt doctor --fix to automatically fix these problems.",
-                    problem_count,
-                    fixable_count
-                );
-            } else {
-                println!(
-                    "Found {} problems. None can be automatically fixed.",
-                    problem_count
-                );
-            }
-        }
-
-        if problem_count > fixed_count {
-            process::exit(1);
-        }
-    } else {
-        println!(
-            "Found no problems. Everything should be fine. If you're still \
-            experiencing issues, please file an issue: \
-            https://github.com/dotboris/alt/issues/new"
-        );
-    }
-}
-
-struct CheckDefsRes {
-    defs: CommandDefs,
-    removed_defs: HashSet<(String, String)>
-}
-fn check_defs(
-    fix: bool,
-    problem_count: &mut u32,
-    fixable_count: &mut u32,
-    fixed_count: &mut u32
-) -> CheckDefsRes {
     let defs = def_file::load();
+    let mut fixed_defs = defs.clone();
 
     if defs.is_empty() {
-        *problem_count += 1;
+        problem_count += 1;
         print_problem(
             "No commands or command versions are defined. This is normal if \
             you've just installed alt. You will need to define some commands \
@@ -92,28 +22,47 @@ fn check_defs(
         println!();
     }
 
-    let mut defs_to_remove = HashSet::new();
-
     for (command, versions) in defs {
         for (version, bin) in versions {
-            let has_problem = def_has_problem(&command, &version, &bin);
+            let has_problem = {
+                if !bin.exists() {
+                    print_problem(&format!(
+                        "Executable for {} version {} ({}) does not exist.",
+                        command, version, bin.display()
+                    ));
+                    true
+                } else if !bin.is_file() {
+                    print_problem(&format!(
+                        "Executable for {} version {} ({}) is not a file.",
+                        command, version, bin.display()
+                    ));
+                    true
+                } else {
+                    false
+                }
+            };
+
             if has_problem {
-                *problem_count += 1;
+                problem_count += 1;
 
-                defs_to_remove.insert(
-                    (command.to_string(), version.to_string())
-                );
+                print_fix_available(&format!(
+                    "Remove entry for {} version {}.",
+                    command, version
+                ));
 
-                if fix {
-                    *fixed_count += 1;
+                if should_fix(&fix_mode) {
+                    fixed_count += 1;
+
+                    def_file::remove_version(&mut fixed_defs, &command, &version);
+
+                    // We are purposefully saving at every step to ensure that
+                    // no fixes are lost if the user does a Ctrl-C to kill the
+                    // process.
+                    def_file::save(&fixed_defs)
+                        .expect("Failed to save command version definitions");
+
                     print_fixed(&format!(
                         "Removed entry for {} version {}.",
-                        command, version
-                    ));
-                } else {
-                    *fixable_count += 1;
-                    print_fixable(&format!(
-                        "Would remove entry for {} version {}.",
                         command, version
                     ));
                 }
@@ -122,42 +71,46 @@ fn check_defs(
         }
     }
 
-    let mut defs = def_file::load();
-    for (command, version) in defs_to_remove.clone() {
-        let versions = defs.get_mut(&command).unwrap();
-        versions.remove(&version);
-        if versions.is_empty() {
-            defs.remove(&command);
-        }
-    }
+    // TODO: check all used versions point to real versions
+    // TODO: check that shims are defined
+    // TODO: check that old shims are not left over
 
-    return CheckDefsRes {
-        defs,
-        removed_defs: defs_to_remove
+    if problem_count > 0 {
+        println!(
+            "Found {} problems. Fixed {}/{}.",
+            problem_count,
+            fixed_count,
+            problem_count
+        );
+
+        if problem_count > fixed_count {
+            process::exit(1);
+        }
+    } else {
+        println!(
+            "{}: Found no problems. Alt should be working correctly. If you're \
+            still experiencing problems, please file an issue: \
+            https://github.com/dotboris/alt/issues/new",
+            console::style("All is good").green().bold()
+        );
     }
 }
 
-
-fn def_has_problem(command: &str, version: &str, bin: &Path) -> bool {
-    if !bin.exists() {
-        print_problem(&format!(
-            "Binary for {} version {} ({}) does not exist.",
-            command, version, bin.display()
-        ));
-        return true;
+fn should_fix(fix_mode: &FixMode) -> bool {
+    match fix_mode {
+        FixMode::Auto => {
+            println!("Applying fix because command was called with --fix-mode auto");
+            true
+        },
+        FixMode::Never => {
+            println!("Did not apply fix because command was called with --fix-mode never");
+            false
+        },
+        FixMode::Prompt => {
+            // TODO: prompt user for fix
+            false
+        },
     }
-
-    if !bin.is_file() {
-        print_problem(&format!(
-            "Binary for {} version {} ({}) is not a file.",
-            command, version, bin.display()
-        ));
-        return true;
-    }
-
-    // TODO: check permissions (readable + executable)
-
-    return false;
 }
 
 fn print_problem(message: &str) {
@@ -167,9 +120,9 @@ fn print_problem(message: &str) {
     );
 }
 
-fn print_fixable(message: &str) {
+fn print_fix_available(message: &str) {
     println!("{}: {}",
-        console::style("Auto-Fixable").bold().cyan(),
+        console::style("Fix Available").bold().cyan(),
         message
     );
 }

--- a/src/doctor_cmd.rs
+++ b/src/doctor_cmd.rs
@@ -99,7 +99,7 @@ pub fn run(fix_mode: FixMode) {
             "{}: Found no problems. Alt should be working correctly. If you're \
             still experiencing problems, please file an issue: \
             https://github.com/dotboris/alt/issues/new",
-            console::style("All is good").green().bold()
+            console::style("All is good").bold().green()
         );
     }
 }

--- a/src/doctor_cmd.rs
+++ b/src/doctor_cmd.rs
@@ -2,6 +2,7 @@ use crate::def_file;
 use std::process;
 use std::os::unix::fs::MetadataExt;
 use console;
+use dialoguer::Confirm;
 
 pub enum FixMode { Auto, Never, Prompt }
 
@@ -114,8 +115,10 @@ fn should_fix(fix_mode: &FixMode) -> bool {
             false
         },
         FixMode::Prompt => {
-            // TODO: prompt user for fix
-            false
+            Confirm::new()
+                .with_prompt("Would you like to apply this fix?")
+                .interact()
+                .unwrap_or(false)
         },
     }
 }

--- a/src/doctor_cmd.rs
+++ b/src/doctor_cmd.rs
@@ -1,5 +1,6 @@
 use crate::def_file;
 use std::process;
+use std::os::unix::fs::MetadataExt;
 use console;
 
 pub enum FixMode { Auto, Never, Prompt }
@@ -27,13 +28,19 @@ pub fn run(fix_mode: FixMode) {
             let has_problem = {
                 if !bin.exists() {
                     print_problem(&format!(
-                        "Executable for {} version {} ({}) does not exist.",
+                        "Bin for {} version {} ({}) does not exist.",
                         command, version, bin.display()
                     ));
                     true
                 } else if !bin.is_file() {
                     print_problem(&format!(
-                        "Executable for {} version {} ({}) is not a file.",
+                        "Bin for {} version {} ({}) is not a file.",
+                        command, version, bin.display()
+                    ));
+                    true
+                } else if bin.metadata().unwrap().mode() & 0o111 == 0 {
+                    print_problem(&format!(
+                        "Bin for {} version {} ({}) is not executable.",
                         command, version, bin.display()
                     ));
                     true

--- a/src/doctor_cmd.rs
+++ b/src/doctor_cmd.rs
@@ -120,7 +120,7 @@ fn should_fix(fix_mode: &FixMode) -> bool {
                 .expect(
                     "Failed to prompt for fix action. \
                     If you're trying to use this command non-interactively, \
-                    try passing in --fix-mod <auto|never>"
+                    try passing in --fix-mode <auto|never>"
                 )
         },
     }

--- a/src/doctor_cmd.rs
+++ b/src/doctor_cmd.rs
@@ -96,7 +96,7 @@ pub fn run(fix_mode: FixMode) {
     } else {
         println!(
             "{}: Found no problems. Alt should be working correctly. If you're \
-            still experiencing problems, please file an issue: \
+            still experiencing problems, please open an issue: \
             https://github.com/dotboris/alt/issues/new",
             console::style("All is good").bold().green()
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,8 +65,15 @@ fn main() {
                     matches.value_of("version")
                 ),
             ("show", Some(_)) => show_cmd::run(),
-            ("doctor", Some(matches)) =>
-                doctor_cmd::run(matches.is_present("fix")),
+            ("doctor", Some(matches)) => {
+                let fix = match matches.value_of("fix_mode") {
+                    Some("auto") => doctor_cmd::FixMode::Auto,
+                    Some("never") => doctor_cmd::FixMode::Never,
+                    Some("prompt") => doctor_cmd::FixMode::Prompt,
+                    _ => unreachable!()
+                };
+                doctor_cmd::run(fix)
+            },
             ("def", Some(matches)) =>
                 def_cmd::run(
                     matches.value_of("command").unwrap(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,13 +66,13 @@ fn main() {
                 ),
             ("show", Some(_)) => show_cmd::run(),
             ("doctor", Some(matches)) => {
-                let fix = match matches.value_of("fix_mode") {
+                let fix_mode = match matches.value_of("fix_mode") {
                     Some("auto") => doctor_cmd::FixMode::Auto,
                     Some("never") => doctor_cmd::FixMode::Never,
                     Some("prompt") => doctor_cmd::FixMode::Prompt,
                     _ => unreachable!()
                 };
-                doctor_cmd::run(fix)
+                doctor_cmd::run(fix_mode)
             },
             ("def", Some(matches)) =>
                 def_cmd::run(

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod which_cmd;
 mod scan_cmd;
 mod use_cmd;
 mod show_cmd;
+mod doctor_cmd;
 mod def_cmd;
 mod cli;
 mod shim;
@@ -64,6 +65,8 @@ fn main() {
                     matches.value_of("version")
                 ),
             ("show", Some(_)) => show_cmd::run(),
+            ("doctor", Some(matches)) =>
+                doctor_cmd::run(matches.is_present("fix")),
             ("def", Some(matches)) =>
                 def_cmd::run(
                     matches.value_of("command").unwrap(),

--- a/tests/doctor_def_test.rs
+++ b/tests/doctor_def_test.rs
@@ -25,7 +25,7 @@ fn success_with_no_problems() -> IoResult<()> {
     env.def("thingy", "1", &bin_v1_path).assert().success();
     env.def("thingy", "2", &bin_v2_path).assert().success();
 
-    env._use("thingy", "1");
+    env._use("thingy", "1").assert().success();
 
     env.alt()
         .args(&["doctor", "--fix-mode", "auto"])

--- a/tests/doctor_def_test.rs
+++ b/tests/doctor_def_test.rs
@@ -9,6 +9,33 @@ use std::io::Result as IoResult;
 use std::os::unix::fs::PermissionsExt;
 
 #[test]
+fn success_with_no_problems() -> IoResult<()> {
+    let env = TestEnv::new();
+
+    env.create_stub_command("thingy", "this is thingy system version")?;
+    let bin_v1_path = env.create_stub_command(
+        "thingy-1",
+        "this is thingy v1"
+    )?;
+    let bin_v2_path = env.create_stub_command(
+        "thingy-2",
+        "this is thingy v2"
+    )?;
+
+    env.def("thingy", "1", &bin_v1_path).assert().success();
+    env.def("thingy", "2", &bin_v2_path).assert().success();
+
+    env._use("thingy", "1");
+
+    env.alt()
+        .args(&["doctor", "--fix-mode", "auto"])
+        .assert()
+        .success();
+
+    Ok(())
+}
+
+#[test]
 fn remove_entry_for_missing_bin() -> IoResult<()> {
     let env = TestEnv::new();
 

--- a/tests/doctor_def_test.rs
+++ b/tests/doctor_def_test.rs
@@ -6,6 +6,7 @@ mod test_env;
 use test_env::TestEnv;
 use std::fs;
 use std::io::Result as IoResult;
+use std::os::unix::fs::PermissionsExt;
 
 #[test]
 fn remove_entry_for_missing_bin() -> IoResult<()> {
@@ -25,6 +26,95 @@ fn remove_entry_for_missing_bin() -> IoResult<()> {
     env.def("thingy", "2", &bin_v2_path).assert().success();
 
     fs::remove_file(bin_v1_path)?;
+
+    env.alt()
+        .arg("show")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("thingy-1")
+                .and(predicate::str::contains("thingy-2"))
+        );
+
+    env.alt()
+        .args(&["doctor", "--fix-mode", "auto"])
+        .spawn()?
+        .wait()?;
+
+    env.alt()
+        .arg("show")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("thingy-1").not()
+                .and(predicate::str::contains("thingy-2"))
+        );
+
+    Ok(())
+}
+
+#[test]
+fn remove_entry_for_defined_dir() -> IoResult<()> {
+    let env = TestEnv::new();
+
+    env.create_stub_command("thingy", "this is thingy system version")?;
+    let bin_v1_path = env.root.join("thingy-1");
+    fs::create_dir(&bin_v1_path)?;
+    let bin_v2_path = env.create_stub_command(
+        "thingy-2",
+        "this is thingy v2"
+    )?;
+
+    env.def("thingy", "1", &bin_v1_path).assert().success();
+    env.def("thingy", "2", &bin_v2_path).assert().success();
+
+    env.alt()
+        .arg("show")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("thingy-1")
+                .and(predicate::str::contains("thingy-2"))
+        );
+
+    env.alt()
+        .args(&["doctor", "--fix-mode", "auto"])
+        .spawn()?
+        .wait()?;
+
+    env.alt()
+        .arg("show")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("thingy-1").not()
+                .and(predicate::str::contains("thingy-2"))
+        );
+
+    Ok(())
+}
+
+#[test]
+fn remove_entry_for_non_executable_bin() -> IoResult<()> {
+    let env = TestEnv::new();
+
+    env.create_stub_command("thingy", "this is thingy system version")?;
+    let bin_v1_path = env.create_stub_command(
+        "thingy-1",
+        "this is thingy v1"
+    )?;
+    let bin_v2_path = env.create_stub_command(
+        "thingy-2",
+        "this is thingy v2"
+    )?;
+
+    env.def("thingy", "1", &bin_v1_path).assert().success();
+    env.def("thingy", "2", &bin_v2_path).assert().success();
+
+    let mut perm = fs::metadata(&bin_v1_path)?
+        .permissions();
+    perm.set_mode(0o644);
+    fs::set_permissions(&bin_v1_path, perm)?;
 
     env.alt()
         .arg("show")

--- a/tests/doctor_def_test.rs
+++ b/tests/doctor_def_test.rs
@@ -1,0 +1,53 @@
+extern crate assert_cmd;
+
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+mod test_env;
+use test_env::TestEnv;
+use std::fs;
+use std::io::Result as IoResult;
+
+#[test]
+fn remove_entry_for_missing_bin() -> IoResult<()> {
+    let env = TestEnv::new();
+
+    env.create_stub_command("thingy", "this is thingy system version")?;
+    let bin_v1_path = env.create_stub_command(
+        "thingy-1",
+        "this is thingy v1"
+    )?;
+    let bin_v2_path = env.create_stub_command(
+        "thingy-2",
+        "this is thingy v2"
+    )?;
+
+    env.def("thingy", "1", &bin_v1_path).assert().success();
+    env.def("thingy", "2", &bin_v2_path).assert().success();
+
+    fs::remove_file(bin_v1_path)?;
+
+    env.alt()
+        .arg("show")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("thingy-1")
+                .and(predicate::str::contains("thingy-2"))
+        );
+
+    env.alt()
+        .args(&["doctor", "--fix-mode", "auto"])
+        .spawn()?
+        .wait()?;
+
+    env.alt()
+        .arg("show")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("thingy-1").not()
+                .and(predicate::str::contains("thingy-2"))
+        );
+
+    Ok(())
+}


### PR DESCRIPTION
The idea for this PR is to allow `alt` to heal itself when it encounter problems.

There is a set of problems that `alt` can encounter that are fairly common. It's a pretty big shame that users are currently stuck trying to fix those problems themselves. Often this can involve editing `alt`'s internal files which can get pretty sketchy.