### PR TITLE
Remove dead code in TestEnv

### DIFF
--- a/tests/test_env.rs
+++ b/tests/test_env.rs
@@ -17,7 +17,6 @@ use self::escargot::CargoBuild;
 #[derive(Debug)]
 pub struct TestEnv {
     pub root: PathBuf,
-    project_root: PathBuf,
     alt_bin: PathBuf,
     stub_bin_dir: PathBuf,
 }
@@ -51,7 +50,6 @@ impl TestEnv {
         TestEnv {
             root,
             stub_bin_dir,
-            project_root: env::current_dir().unwrap(),
             alt_bin: PathBuf::from(bin.path()),
         }
     }


### PR DESCRIPTION
In #185, I noticed that the build was failing with the following error:

```
error: field is never read: `project_root`
  --> tests/test_env.rs:20:5
   |
20 |     project_root: PathBuf,
   |     ^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `-D dead-code` implied by `-D warnings`
```
 (Source: https://github.com/dotboris/alt/runs/4580832229?check_suite_focus=true)

I tried to run it on master and it fails as well in the exact same way: https://github.com/dotboris/alt/runs/4584481295?check_suite_focus=true

Looks like a new `clippy` update introduced a new check or improved an existing one.