### PR TITLE
Add cli self test to tests

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -101,3 +101,8 @@ pub fn make_app() -> Command<'static> {
                 ),
         );
 }
+
+#[test]
+fn verify_app() {
+    make_app().debug_assert();
+}


### PR DESCRIPTION
This follows recommendations from the clap migration guide. The idea is that clap can do a basic self check when using the builder pattern and tells us if everything's OK. This moves the check to tests so that we can see it sooner.