### PR TITLE
Migrate to `clap@v4`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,26 +65,6 @@ jobs:
         with:
           command: test
 
-  run-help:
-    name: run help command
-
-    strategy:
-      matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-      - uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: help
-
   package:
     uses: ./.github/workflows/package.yml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Migrate to Rust 2021 Edition. This should have no effect on users but may
   affect people building from source.
+- Migrate to `clap@v4`. This changes the way the help text is rendered. In terms
+  of behavior, nothing should change.
 
 <!-- section:previous-releases -->
 ## [v1.2.1] 2022-06-24

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contribution Guide
+
+## Cheat sheet
+
+```sh
+# build
+cargo build
+
+# run a local version of alt
+cargo run ...
+
+# test
+cargo test
+
+# format
+cargo fmt
+
+# lint
+cargo clippy
+```
+
+## Setup
+
+This project is built with rust. You'll need to have rust installed.
+See: <https://www.rust-lang.org/tools/install>
+
+## Snapshot tests
+
+Some of the tests in this projects are snapshot based. Instead of asserting on
+hard coded values, these tests use previously stored snapshots to ensure that
+certain important values don't change.
+
+These tests are built using the [`insta`](https://crates.io/crates/insta) crate.
+You don't need any special tools to run these tests.
+
+If you need to change these tests or break them and need to change them. Please
+see <https://insta.rs/docs/quickstart/> for a quick guide on how to use them.
+You'll mostly likely want to install the
+[`cargo-insta`](https://crates.io/crates/cargo-insta) CLI which helps with
+managing snapshots.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,10 +22,13 @@ dependencies = [
  "dialoguer",
  "escargot",
  "glob",
+ "insta",
  "lazy_static",
  "predicates",
  "rand 0.8.5",
  "regex",
+ "serde",
+ "test-case",
  "toml",
 ]
 
@@ -45,10 +48,11 @@ dependencies = [
 
 [[package]]
 name = "atty"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
+ "hermit-abi",
  "libc",
  "winapi",
 ]
@@ -97,6 +101,12 @@ name = "cfg-if"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
@@ -208,7 +218,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc344b02d3868feb131e8b5fe2b9b0a1cc42942679af493061fc13b853243872"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.9",
  "libc",
  "wasi 0.5.0",
 ]
@@ -219,7 +229,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee8025cf36f917e6a52cce185b7c7177689b838b7ec138364e50cc2277a56cf4"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.9",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -232,25 +242,50 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "indexmap"
-version = "1.8.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
 ]
 
 [[package]]
-name = "itertools"
-version = "0.10.1"
+name = "insta"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+checksum = "581d4e3314cae4536e5d22ffd23189d4a374696c5ef733eadafae0ed273fd303"
+dependencies = [
+ "console",
+ "lazy_static",
+ "linked-hash-map",
+ "regex",
+ "serde",
+ "similar",
+ "toml",
+ "yaml-rust",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
@@ -274,12 +309,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "log"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.9",
 ]
 
 [[package]]
@@ -352,12 +393,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.34"
+name = "proc-macro-error"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f84e92c0f7c9d58328b85a78557813e4bd845130db68d7184635344399423b1"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
- "unicode-xid",
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -489,18 +554,18 @@ checksum = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
 
 [[package]]
 name = "serde"
-version = "1.0.132"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.132"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
+checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -519,6 +584,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ac7f900db32bf3fd12e0117dd3dc4da74bc52ebaac97f39668446d89694803"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,13 +597,13 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.82"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -541,7 +612,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.9",
  "libc",
  "rand 0.7.3",
  "redox_syscall",
@@ -569,6 +640,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-case"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21d6cf5a7dffb3f9dceec8e6b8ca528d9bd71d36c9f074defb548ce161f598c0"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e45b7bf6e19353ddd832745c8fcf77a17a93171df7151187f26623f2b75b5b26"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,16 +683,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.0"
+name = "version_check"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wait-timeout"
@@ -652,6 +751,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,34 +116,33 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "335867764ed2de42325fafe6d18b8af74ba97ee0c590fa016f157535b42ab04b"
 dependencies = [
  "atty",
  "bitflags",
  "clap_lex",
- "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
+ "terminal_size 0.2.1",
 ]
 
 [[package]]
 name = "clap_complete"
-version = "3.2.5"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f7a2e0a962c45ce25afce14220bc24f9dade0a1787f185cecf96bfba7847cd8"
+checksum = "dfe581a2035db4174cdbdc91265e1aba50f381577f0510d0ad36c7bc59cc84a3"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -151,7 +156,7 @@ dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
- "terminal_size",
+ "terminal_size 0.1.15",
  "unicode-width",
  "winapi",
 ]
@@ -190,6 +195,27 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "escargot"
@@ -241,28 +267,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
-dependencies = [
- "autocfg",
- "hashbrown",
 ]
 
 [[package]]
@@ -280,6 +290,12 @@ dependencies = [
  "toml",
  "yaml-rust",
 ]
+
+[[package]]
+name = "io-lifetimes"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e481ccbe3dea62107216d0d1138bb8ad8e5e5c43009a098bd1990272c497b0"
 
 [[package]]
 name = "itertools"
@@ -304,15 +320,21 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.81"
+version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
 
 [[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "log"
@@ -427,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.2"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -547,6 +569,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.35.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbb2fda4666def1433b1b05431ab402e42a1084285477222b72d6c564c417cef"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,6 +676,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8440c860cf79def6164e4a0a983bcc2305d82419177a0e0c71930d049e3ac5a1"
+dependencies = [
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "test-case"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,12 +706,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "toml"
@@ -751,6 +791,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,12 @@ assets = [
 [profile.release]
 lto = true
 
+[profile.dev.package.insta]
+opt-level = 3
+
+[profile.dev.package.similar]
+opt-level = 3
+
 [dependencies]
 toml = "0.5.9"
 console = "0.15.2"
@@ -44,8 +50,11 @@ features = ["std", "perf", "unicode-perl"]
 [dev-dependencies]
 assert_cmd = "2.0"
 escargot = "0.5"
+insta = { version = "1.21.0", features = ["filters", "toml"] }
 predicates = "2.1.1"
 rand = "0.8"
+serde = "1.0.147"
+test-case = "2.2.2"
 
 [build-dependencies]
 clap_complete = "3.2.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,16 +31,12 @@ opt-level = 3
 opt-level = 3
 
 [dependencies]
+clap = { version = "4.0.18", features = ["cargo", "wrap_help"] }
 toml = "0.5.9"
 console = "0.15.2"
 lazy_static = "1.4.0"
 dialoguer = "0.10.2"
 glob = "0.3.0"
-
-[dependencies.clap]
-version = "3.2.22"
-default-features = true
-features = ["cargo"]
 
 [dependencies.regex]
 version = "1"
@@ -57,9 +53,5 @@ serde = "1.0.147"
 test-case = "2.2.2"
 
 [build-dependencies]
-clap_complete = "3.2.5"
-
-[build-dependencies.clap]
-version = "3.2.22"
-default-features = true
-features = ["cargo"]
+clap = { version = "4.0.18", features = ["cargo"] }
+clap_complete = "4.0.3"

--- a/README.md
+++ b/README.md
@@ -211,22 +211,4 @@ https://help.github.com/articles/ignoring-files/#create-a-global-gitignore
 echo '.alt.toml' >> path/to/your/global-gitgnore
 ```
 
-## Development
-
-### Setup
-
-See: <https://www.rust-lang.org/tools/install>
-
-### Run
-
-```sh
-cargo run ...
-```
-
-### Test
-
-```sh
-cargo test
-```
-
 [latest-release]: https://github.com/dotboris/alt/releases/latest

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,5 @@
 use clap::builder::PossibleValuesParser;
+use clap::ArgAction::StoreValue;
 use clap::{crate_version, Arg, Command};
 
 pub fn make_app() -> Command<'static> {
@@ -24,11 +25,13 @@ pub fn make_app() -> Command<'static> {
                 )
                 .arg(
                     Arg::new("command")
+                        .action(StoreValue)
                         .help("The command to run")
                         .required(true),
                 )
                 .arg(
                     Arg::new("command_args")
+                        .action(StoreValue)
                         .help("Arguments to pass to the command")
                         .multiple_values(true),
                 ),
@@ -39,6 +42,7 @@ pub fn make_app() -> Command<'static> {
                 .about("Print the resolved path of a command")
                 .arg(
                     Arg::new("command")
+                        .action(StoreValue)
                         .required(true)
                         .help("Command to look up"),
                 ),
@@ -48,6 +52,7 @@ pub fn make_app() -> Command<'static> {
                 .about("Scan for different versions of the given command")
                 .arg(
                     Arg::new("command")
+                        .action(StoreValue)
                         .required(true)
                         .help("Command to scan for"),
                 ),
@@ -63,10 +68,15 @@ pub fn make_app() -> Command<'static> {
                 )
                 .arg(
                     Arg::new("command")
+                        .action(StoreValue)
                         .required(true)
                         .help("Command to switch the version of"),
                 )
-                .arg(Arg::new("version").help("Version to use (optional)")),
+                .arg(
+                    Arg::new("version")
+                        .action(StoreValue)
+                        .help("Version to use (optional)"),
+                ),
         )
         .subcommand(Command::new("show").about("Print commands and their versions"))
         .subcommand(
@@ -74,16 +84,19 @@ pub fn make_app() -> Command<'static> {
                 .about("Define a new version")
                 .arg(
                     Arg::new("command")
+                        .action(StoreValue)
                         .required(true)
                         .help("Command to define the version for"),
                 )
                 .arg(
                     Arg::new("version")
+                        .action(StoreValue)
                         .required(true)
                         .help("The name of the version"),
                 )
                 .arg(
                     Arg::new("bin")
+                        .action(StoreValue)
                         .required(true)
                         .help("Path to the executable for the version"),
                 ),
@@ -95,6 +108,7 @@ pub fn make_app() -> Command<'static> {
                     Arg::new("fix_mode")
                         .short('f')
                         .long("fix-mode")
+                        .action(StoreValue)
                         .value_parser(PossibleValuesParser::new(["auto", "never", "prompt"]))
                         .takes_value(true)
                         .default_value("prompt")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,8 @@
 use clap::builder::PossibleValuesParser;
-use clap::ArgAction::StoreValue;
+use clap::ArgAction;
 use clap::{crate_version, Arg, Command};
 
-pub fn make_app() -> Command<'static> {
+pub fn make_app() -> Command {
     return Command::new("alt")
         .version(crate_version!())
         .about("Switch between different versions of commands")
@@ -25,15 +25,13 @@ pub fn make_app() -> Command<'static> {
                 )
                 .arg(
                     Arg::new("command")
-                        .action(StoreValue)
                         .help("The command to run")
                         .required(true),
                 )
                 .arg(
                     Arg::new("command_args")
-                        .action(StoreValue)
-                        .help("Arguments to pass to the command")
-                        .multiple_values(true),
+                        .action(ArgAction::Append)
+                        .help("Arguments to pass to the command"),
                 ),
         )
         .subcommand(Command::new("shim").about("Generate shims for all managed commands"))
@@ -42,7 +40,6 @@ pub fn make_app() -> Command<'static> {
                 .about("Print the resolved path of a command")
                 .arg(
                     Arg::new("command")
-                        .action(StoreValue)
                         .required(true)
                         .help("Command to look up"),
                 ),
@@ -52,7 +49,6 @@ pub fn make_app() -> Command<'static> {
                 .about("Scan for different versions of the given command")
                 .arg(
                     Arg::new("command")
-                        .action(StoreValue)
                         .required(true)
                         .help("Command to scan for"),
                 ),
@@ -68,13 +64,11 @@ pub fn make_app() -> Command<'static> {
                 )
                 .arg(
                     Arg::new("command")
-                        .action(StoreValue)
                         .required(true)
                         .help("Command to switch the version of"),
                 )
                 .arg(
                     Arg::new("version")
-                        .action(StoreValue)
                         .help("Version to use (optional)"),
                 ),
         )
@@ -84,19 +78,16 @@ pub fn make_app() -> Command<'static> {
                 .about("Define a new version")
                 .arg(
                     Arg::new("command")
-                        .action(StoreValue)
                         .required(true)
                         .help("Command to define the version for"),
                 )
                 .arg(
                     Arg::new("version")
-                        .action(StoreValue)
                         .required(true)
                         .help("The name of the version"),
                 )
                 .arg(
                     Arg::new("bin")
-                        .action(StoreValue)
                         .required(true)
                         .help("Path to the executable for the version"),
                 ),
@@ -108,9 +99,7 @@ pub fn make_app() -> Command<'static> {
                     Arg::new("fix_mode")
                         .short('f')
                         .long("fix-mode")
-                        .action(StoreValue)
                         .value_parser(PossibleValuesParser::new(["auto", "never", "prompt"]))
-                        .takes_value(true)
                         .default_value("prompt")
                         .help("Control how automatic fixes are applied."),
                 ),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,7 @@ use clap::ArgAction;
 use clap::{crate_version, Arg, Command};
 
 pub fn make_app() -> Command {
-    return Command::new("alt")
+    Command::new("alt")
         .version(crate_version!())
         .about("Switch between different versions of commands")
         .subcommand_required(true)
@@ -67,10 +67,7 @@ pub fn make_app() -> Command {
                         .required(true)
                         .help("Command to switch the version of"),
                 )
-                .arg(
-                    Arg::new("version")
-                        .help("Version to use (optional)"),
-                ),
+                .arg(Arg::new("version").help("Version to use (optional)")),
         )
         .subcommand(Command::new("show").about("Print commands and their versions"))
         .subcommand(
@@ -103,7 +100,7 @@ pub fn make_app() -> Command {
                         .default_value("prompt")
                         .help("Control how automatic fixes are applied."),
                 ),
-        );
+        )
 }
 
 #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,7 @@ pub fn shim_dir() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use crate::config;
+    use lazy_static::lazy_static;
     use std::env;
     use std::path::{Path, PathBuf};
     use std::sync::Mutex;

--- a/src/def_file.rs
+++ b/src/def_file.rs
@@ -1,5 +1,3 @@
-extern crate toml;
-
 use crate::config;
 use std::collections::HashMap;
 use std::fs;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,3 @@
-extern crate clap;
-extern crate console;
-#[macro_use]
-extern crate lazy_static;
-extern crate glob;
-extern crate regex;
-
 mod checks;
 mod cli;
 mod command;

--- a/src/scan/path_suffix.rs
+++ b/src/scan/path_suffix.rs
@@ -1,5 +1,6 @@
 use super::CommandVersion;
 use crate::config;
+use lazy_static::lazy_static;
 use regex::Regex;
 use std::env;
 use std::fs;

--- a/src/scan_cmd.rs
+++ b/src/scan_cmd.rs
@@ -1,6 +1,3 @@
-extern crate dialoguer;
-extern crate toml;
-
 use crate::def_file;
 use crate::scan;
 use crate::scan::CommandVersion;

--- a/src/use_cmd.rs
+++ b/src/use_cmd.rs
@@ -1,5 +1,3 @@
-extern crate dialoguer;
-
 use crate::def_file;
 use crate::use_file;
 use dialoguer::Select;

--- a/src/use_file.rs
+++ b/src/use_file.rs
@@ -1,5 +1,3 @@
-extern crate toml;
-
 use std::collections::HashMap;
 use std::fs;
 use std::io;

--- a/tests/doctor_def_test.rs
+++ b/tests/doctor_def_test.rs
@@ -1,5 +1,3 @@
-extern crate assert_cmd;
-
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
 mod test_env;

--- a/tests/doctor_def_test.rs
+++ b/tests/doctor_def_test.rs
@@ -1,6 +1,7 @@
+mod test_env;
+
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
-mod test_env;
 use std::fs;
 use std::io::Result as IoResult;
 use std::os::unix::fs::PermissionsExt;

--- a/tests/help_test.rs
+++ b/tests/help_test.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 
 mod test_env;
+
 use clap::crate_version;
 use serde::Serialize;
 use std::{convert::TryFrom, error::Error, process::Output};

--- a/tests/help_test.rs
+++ b/tests/help_test.rs
@@ -1,0 +1,65 @@
+#![cfg(test)]
+
+mod test_env;
+use clap::crate_version;
+use serde::Serialize;
+use std::{convert::TryFrom, error::Error, process::Output};
+use test_case::test_case;
+use test_env::TestEnv;
+
+type TestResult = Result<(), Box<dyn Error>>;
+
+#[derive(Debug, Serialize)]
+struct OutputSnapshot {
+    status: i32,
+    stdout: String,
+    stderr: String,
+}
+
+impl TryFrom<Output> for OutputSnapshot {
+    type Error = Box<dyn Error>;
+
+    fn try_from(value: Output) -> Result<Self, Self::Error> {
+        let res = OutputSnapshot {
+            status: value.status.code().ok_or("unable to read status code")?,
+            stdout: String::from_utf8(value.stdout)?,
+            stderr: String::from_utf8(value.stderr)?,
+        };
+
+        Ok(res)
+    }
+}
+
+#[test_case(vec!["help"]; "help command")]
+#[test_case(vec!["--help"]; "long help flag")]
+#[test_case(vec!["-h"]; "short help flag")]
+#[test_case(vec!["def", "--help"]; "def long help flag")]
+#[test_case(vec!["def", "-h"]; "def short help flag")]
+#[test_case(vec!["doctor", "--help"]; "doctor long help flag")]
+#[test_case(vec!["doctor", "-h"]; "doctor short help flag")]
+#[test_case(vec!["exec", "--help"]; "exec long help flag")]
+#[test_case(vec!["exec", "-h"]; "exec short help flag")]
+#[test_case(vec!["scan", "--help"]; "scan long help flag")]
+#[test_case(vec!["scan", "-h"]; "scan short help flag")]
+#[test_case(vec!["shim", "--help"]; "shim long help flag")]
+#[test_case(vec!["shim", "-h"]; "shim short help flag")]
+#[test_case(vec!["show", "--help"]; "show long help flag")]
+#[test_case(vec!["show", "-h"]; "show short help flag")]
+#[test_case(vec!["use", "--help"]; "use long help flag")]
+#[test_case(vec!["use", "-h"]; "use short help flag")]
+#[test_case(vec!["which", "--help"]; "which long help flag")]
+#[test_case(vec!["which", "-h"]; "which short help flag")]
+fn test_help(args: Vec<&str>) -> TestResult {
+    let env = TestEnv::new();
+    let output = env.alt().args(&args).output()?;
+
+    let snapshot = OutputSnapshot::try_from(output)?;
+    insta::with_settings!({
+        filters => vec![(regex::escape(crate_version!()).as_str(), "[version]")],
+        snapshot_suffix => args.join("_"),
+    }, {
+        insta::assert_toml_snapshot!(snapshot);
+    });
+
+    Ok(())
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,5 +1,3 @@
-extern crate assert_cmd;
-
 use assert_cmd::prelude::*;
 mod test_env;
 use std::fs;

--- a/tests/snapshots/help_test__help@--help.snap
+++ b/tests/snapshots/help_test__help@--help.snap
@@ -1,0 +1,28 @@
+---
+source: tests/help_test.rs
+expression: snapshot
+---
+status = 0
+stdout = '''
+alt [version]
+Switch between different versions of commands
+
+USAGE:
+    alt <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    def       Define a new version
+    doctor    Checks if alt is setup correctly. Helps debug problems.
+    exec      Run the given command
+    help      Print this message or the help of the given subcommand(s)
+    scan      Scan for different versions of the given command
+    shim      Generate shims for all managed commands
+    show      Print commands and their versions
+    use       Switch the version of a command
+    which     Print the resolved path of a command
+'''
+stderr = ''

--- a/tests/snapshots/help_test__help@--help.snap
+++ b/tests/snapshots/help_test__help@--help.snap
@@ -4,25 +4,23 @@ expression: snapshot
 ---
 status = 0
 stdout = '''
-alt [version]
 Switch between different versions of commands
 
-USAGE:
-    alt <SUBCOMMAND>
+Usage: alt <COMMAND>
 
-OPTIONS:
-    -h, --help       Print help information
-    -V, --version    Print version information
+Commands:
+  exec    Run the given command
+  shim    Generate shims for all managed commands
+  which   Print the resolved path of a command
+  scan    Scan for different versions of the given command
+  use     Switch the version of a command
+  show    Print commands and their versions
+  def     Define a new version
+  doctor  Checks if alt is setup correctly. Helps debug problems.
+  help    Print this message or the help of the given subcommand(s)
 
-SUBCOMMANDS:
-    def       Define a new version
-    doctor    Checks if alt is setup correctly. Helps debug problems.
-    exec      Run the given command
-    help      Print this message or the help of the given subcommand(s)
-    scan      Scan for different versions of the given command
-    shim      Generate shims for all managed commands
-    show      Print commands and their versions
-    use       Switch the version of a command
-    which     Print the resolved path of a command
+Options:
+  -h, --help     Print help information
+  -V, --version  Print version information
 '''
 stderr = ''

--- a/tests/snapshots/help_test__help@-h.snap
+++ b/tests/snapshots/help_test__help@-h.snap
@@ -1,0 +1,28 @@
+---
+source: tests/help_test.rs
+expression: snapshot
+---
+status = 0
+stdout = '''
+alt [version]
+Switch between different versions of commands
+
+USAGE:
+    alt <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    def       Define a new version
+    doctor    Checks if alt is setup correctly. Helps debug problems.
+    exec      Run the given command
+    help      Print this message or the help of the given subcommand(s)
+    scan      Scan for different versions of the given command
+    shim      Generate shims for all managed commands
+    show      Print commands and their versions
+    use       Switch the version of a command
+    which     Print the resolved path of a command
+'''
+stderr = ''

--- a/tests/snapshots/help_test__help@-h.snap
+++ b/tests/snapshots/help_test__help@-h.snap
@@ -4,25 +4,23 @@ expression: snapshot
 ---
 status = 0
 stdout = '''
-alt [version]
 Switch between different versions of commands
 
-USAGE:
-    alt <SUBCOMMAND>
+Usage: alt <COMMAND>
 
-OPTIONS:
-    -h, --help       Print help information
-    -V, --version    Print version information
+Commands:
+  exec    Run the given command
+  shim    Generate shims for all managed commands
+  which   Print the resolved path of a command
+  scan    Scan for different versions of the given command
+  use     Switch the version of a command
+  show    Print commands and their versions
+  def     Define a new version
+  doctor  Checks if alt is setup correctly. Helps debug problems.
+  help    Print this message or the help of the given subcommand(s)
 
-SUBCOMMANDS:
-    def       Define a new version
-    doctor    Checks if alt is setup correctly. Helps debug problems.
-    exec      Run the given command
-    help      Print this message or the help of the given subcommand(s)
-    scan      Scan for different versions of the given command
-    shim      Generate shims for all managed commands
-    show      Print commands and their versions
-    use       Switch the version of a command
-    which     Print the resolved path of a command
+Options:
+  -h, --help     Print help information
+  -V, --version  Print version information
 '''
 stderr = ''

--- a/tests/snapshots/help_test__help@def_--help.snap
+++ b/tests/snapshots/help_test__help@def_--help.snap
@@ -1,0 +1,21 @@
+---
+source: tests/help_test.rs
+expression: snapshot
+---
+status = 0
+stdout = '''
+alt-def 
+Define a new version
+
+USAGE:
+    alt def <command> <version> <bin>
+
+ARGS:
+    <command>    Command to define the version for
+    <version>    The name of the version
+    <bin>        Path to the executable for the version
+
+OPTIONS:
+    -h, --help    Print help information
+'''
+stderr = ''

--- a/tests/snapshots/help_test__help@def_--help.snap
+++ b/tests/snapshots/help_test__help@def_--help.snap
@@ -4,18 +4,16 @@ expression: snapshot
 ---
 status = 0
 stdout = '''
-alt-def 
 Define a new version
 
-USAGE:
-    alt def <command> <version> <bin>
+Usage: alt def <command> <version> <bin>
 
-ARGS:
-    <command>    Command to define the version for
-    <version>    The name of the version
-    <bin>        Path to the executable for the version
+Arguments:
+  <command>  Command to define the version for
+  <version>  The name of the version
+  <bin>      Path to the executable for the version
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help information
 '''
 stderr = ''

--- a/tests/snapshots/help_test__help@def_-h.snap
+++ b/tests/snapshots/help_test__help@def_-h.snap
@@ -1,0 +1,21 @@
+---
+source: tests/help_test.rs
+expression: snapshot
+---
+status = 0
+stdout = '''
+alt-def 
+Define a new version
+
+USAGE:
+    alt def <command> <version> <bin>
+
+ARGS:
+    <command>    Command to define the version for
+    <version>    The name of the version
+    <bin>        Path to the executable for the version
+
+OPTIONS:
+    -h, --help    Print help information
+'''
+stderr = ''

--- a/tests/snapshots/help_test__help@def_-h.snap
+++ b/tests/snapshots/help_test__help@def_-h.snap
@@ -4,18 +4,16 @@ expression: snapshot
 ---
 status = 0
 stdout = '''
-alt-def 
 Define a new version
 
-USAGE:
-    alt def <command> <version> <bin>
+Usage: alt def <command> <version> <bin>
 
-ARGS:
-    <command>    Command to define the version for
-    <version>    The name of the version
-    <bin>        Path to the executable for the version
+Arguments:
+  <command>  Command to define the version for
+  <version>  The name of the version
+  <bin>      Path to the executable for the version
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help information
 '''
 stderr = ''

--- a/tests/snapshots/help_test__help@doctor_--help.snap
+++ b/tests/snapshots/help_test__help@doctor_--help.snap
@@ -4,15 +4,13 @@ expression: snapshot
 ---
 status = 0
 stdout = '''
-alt-doctor 
 Checks if alt is setup correctly. Helps debug problems.
 
-USAGE:
-    alt doctor [OPTIONS]
+Usage: alt doctor [OPTIONS]
 
-OPTIONS:
-    -f, --fix-mode <fix_mode>    Control how automatic fixes are applied. [default: prompt]
-                                 [possible values: auto, never, prompt]
-    -h, --help                   Print help information
+Options:
+  -f, --fix-mode <fix_mode>  Control how automatic fixes are applied. [default: prompt] [possible
+                             values: auto, never, prompt]
+  -h, --help                 Print help information
 '''
 stderr = ''

--- a/tests/snapshots/help_test__help@doctor_--help.snap
+++ b/tests/snapshots/help_test__help@doctor_--help.snap
@@ -1,0 +1,18 @@
+---
+source: tests/help_test.rs
+expression: snapshot
+---
+status = 0
+stdout = '''
+alt-doctor 
+Checks if alt is setup correctly. Helps debug problems.
+
+USAGE:
+    alt doctor [OPTIONS]
+
+OPTIONS:
+    -f, --fix-mode <fix_mode>    Control how automatic fixes are applied. [default: prompt]
+                                 [possible values: auto, never, prompt]
+    -h, --help                   Print help information
+'''
+stderr = ''

--- a/tests/snapshots/help_test__help@doctor_-h.snap
+++ b/tests/snapshots/help_test__help@doctor_-h.snap
@@ -4,15 +4,13 @@ expression: snapshot
 ---
 status = 0
 stdout = '''
-alt-doctor 
 Checks if alt is setup correctly. Helps debug problems.
 
-USAGE:
-    alt doctor [OPTIONS]
+Usage: alt doctor [OPTIONS]
 
-OPTIONS:
-    -f, --fix-mode <fix_mode>    Control how automatic fixes are applied. [default: prompt]
-                                 [possible values: auto, never, prompt]
-    -h, --help                   Print help information
+Options:
+  -f, --fix-mode <fix_mode>  Control how automatic fixes are applied. [default: prompt] [possible
+                             values: auto, never, prompt]
+  -h, --help                 Print help information
 '''
 stderr = ''

--- a/tests/snapshots/help_test__help@doctor_-h.snap
+++ b/tests/snapshots/help_test__help@doctor_-h.snap
@@ -1,0 +1,18 @@
+---
+source: tests/help_test.rs
+expression: snapshot
+---
+status = 0
+stdout = '''
+alt-doctor 
+Checks if alt is setup correctly. Helps debug problems.
+
+USAGE:
+    alt doctor [OPTIONS]
+
+OPTIONS:
+    -f, --fix-mode <fix_mode>    Control how automatic fixes are applied. [default: prompt]
+                                 [possible values: auto, never, prompt]
+    -h, --help                   Print help information
+'''
+stderr = ''

--- a/tests/snapshots/help_test__help@exec_--help.snap
+++ b/tests/snapshots/help_test__help@exec_--help.snap
@@ -1,0 +1,31 @@
+---
+source: tests/help_test.rs
+expression: snapshot
+---
+status = 0
+stdout = '''
+alt-exec 
+Run the given command
+
+USAGE:
+    alt exec <command> [command_args]...
+
+ARGS:
+    <command>            The command to run
+    <command_args>...    Arguments to pass to the command
+
+OPTIONS:
+    -h, --help    Print help information
+
+ARGS NOTE:
+    Note that `alt exec` handles some flags on its own (`--help` for example).
+    If you want to pass such arguments to the executed command instead of
+    `alt exec`, you will need to use `--` to tell alt exec to stop parsing
+    arguments.
+
+    Example:
+
+    alt exec node --help        # --help passed to alt (shows this message)
+    alt exec node -- --help     # --help passed to node (shows node's help)
+'''
+stderr = ''

--- a/tests/snapshots/help_test__help@exec_--help.snap
+++ b/tests/snapshots/help_test__help@exec_--help.snap
@@ -4,18 +4,16 @@ expression: snapshot
 ---
 status = 0
 stdout = '''
-alt-exec 
 Run the given command
 
-USAGE:
-    alt exec <command> [command_args]...
+Usage: alt exec <command> [command_args]...
 
-ARGS:
-    <command>            The command to run
-    <command_args>...    Arguments to pass to the command
+Arguments:
+  <command>          The command to run
+  [command_args]...  Arguments to pass to the command
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help information
 
 ARGS NOTE:
     Note that `alt exec` handles some flags on its own (`--help` for example).

--- a/tests/snapshots/help_test__help@exec_-h.snap
+++ b/tests/snapshots/help_test__help@exec_-h.snap
@@ -1,0 +1,31 @@
+---
+source: tests/help_test.rs
+expression: snapshot
+---
+status = 0
+stdout = '''
+alt-exec 
+Run the given command
+
+USAGE:
+    alt exec <command> [command_args]...
+
+ARGS:
+    <command>            The command to run
+    <command_args>...    Arguments to pass to the command
+
+OPTIONS:
+    -h, --help    Print help information
+
+ARGS NOTE:
+    Note that `alt exec` handles some flags on its own (`--help` for example).
+    If you want to pass such arguments to the executed command instead of
+    `alt exec`, you will need to use `--` to tell alt exec to stop parsing
+    arguments.
+
+    Example:
+
+    alt exec node --help        # --help passed to alt (shows this message)
+    alt exec node -- --help     # --help passed to node (shows node's help)
+'''
+stderr = ''

--- a/tests/snapshots/help_test__help@exec_-h.snap
+++ b/tests/snapshots/help_test__help@exec_-h.snap
@@ -4,18 +4,16 @@ expression: snapshot
 ---
 status = 0
 stdout = '''
-alt-exec 
 Run the given command
 
-USAGE:
-    alt exec <command> [command_args]...
+Usage: alt exec <command> [command_args]...
 
-ARGS:
-    <command>            The command to run
-    <command_args>...    Arguments to pass to the command
+Arguments:
+  <command>          The command to run
+  [command_args]...  Arguments to pass to the command
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help information
 
 ARGS NOTE:
     Note that `alt exec` handles some flags on its own (`--help` for example).

--- a/tests/snapshots/help_test__help@help.snap
+++ b/tests/snapshots/help_test__help@help.snap
@@ -1,0 +1,28 @@
+---
+source: tests/help_test.rs
+expression: snapshot
+---
+status = 0
+stdout = '''
+alt [version]
+Switch between different versions of commands
+
+USAGE:
+    alt <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    def       Define a new version
+    doctor    Checks if alt is setup correctly. Helps debug problems.
+    exec      Run the given command
+    help      Print this message or the help of the given subcommand(s)
+    scan      Scan for different versions of the given command
+    shim      Generate shims for all managed commands
+    show      Print commands and their versions
+    use       Switch the version of a command
+    which     Print the resolved path of a command
+'''
+stderr = ''

--- a/tests/snapshots/help_test__help@help.snap
+++ b/tests/snapshots/help_test__help@help.snap
@@ -4,25 +4,23 @@ expression: snapshot
 ---
 status = 0
 stdout = '''
-alt [version]
 Switch between different versions of commands
 
-USAGE:
-    alt <SUBCOMMAND>
+Usage: alt <COMMAND>
 
-OPTIONS:
-    -h, --help       Print help information
-    -V, --version    Print version information
+Commands:
+  exec    Run the given command
+  shim    Generate shims for all managed commands
+  which   Print the resolved path of a command
+  scan    Scan for different versions of the given command
+  use     Switch the version of a command
+  show    Print commands and their versions
+  def     Define a new version
+  doctor  Checks if alt is setup correctly. Helps debug problems.
+  help    Print this message or the help of the given subcommand(s)
 
-SUBCOMMANDS:
-    def       Define a new version
-    doctor    Checks if alt is setup correctly. Helps debug problems.
-    exec      Run the given command
-    help      Print this message or the help of the given subcommand(s)
-    scan      Scan for different versions of the given command
-    shim      Generate shims for all managed commands
-    show      Print commands and their versions
-    use       Switch the version of a command
-    which     Print the resolved path of a command
+Options:
+  -h, --help     Print help information
+  -V, --version  Print version information
 '''
 stderr = ''

--- a/tests/snapshots/help_test__help@scan_--help.snap
+++ b/tests/snapshots/help_test__help@scan_--help.snap
@@ -4,16 +4,14 @@ expression: snapshot
 ---
 status = 0
 stdout = '''
-alt-scan 
 Scan for different versions of the given command
 
-USAGE:
-    alt scan <command>
+Usage: alt scan <command>
 
-ARGS:
-    <command>    Command to scan for
+Arguments:
+  <command>  Command to scan for
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help information
 '''
 stderr = ''

--- a/tests/snapshots/help_test__help@scan_--help.snap
+++ b/tests/snapshots/help_test__help@scan_--help.snap
@@ -1,0 +1,19 @@
+---
+source: tests/help_test.rs
+expression: snapshot
+---
+status = 0
+stdout = '''
+alt-scan 
+Scan for different versions of the given command
+
+USAGE:
+    alt scan <command>
+
+ARGS:
+    <command>    Command to scan for
+
+OPTIONS:
+    -h, --help    Print help information
+'''
+stderr = ''

--- a/tests/snapshots/help_test__help@scan_-h.snap
+++ b/tests/snapshots/help_test__help@scan_-h.snap
@@ -4,16 +4,14 @@ expression: snapshot
 ---
 status = 0
 stdout = '''
-alt-scan 
 Scan for different versions of the given command
 
-USAGE:
-    alt scan <command>
+Usage: alt scan <command>
 
-ARGS:
-    <command>    Command to scan for
+Arguments:
+  <command>  Command to scan for
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help information
 '''
 stderr = ''

--- a/tests/snapshots/help_test__help@scan_-h.snap
+++ b/tests/snapshots/help_test__help@scan_-h.snap
@@ -1,0 +1,19 @@
+---
+source: tests/help_test.rs
+expression: snapshot
+---
+status = 0
+stdout = '''
+alt-scan 
+Scan for different versions of the given command
+
+USAGE:
+    alt scan <command>
+
+ARGS:
+    <command>    Command to scan for
+
+OPTIONS:
+    -h, --help    Print help information
+'''
+stderr = ''

--- a/tests/snapshots/help_test__help@shim_--help.snap
+++ b/tests/snapshots/help_test__help@shim_--help.snap
@@ -1,0 +1,16 @@
+---
+source: tests/help_test.rs
+expression: snapshot
+---
+status = 0
+stdout = '''
+alt-shim 
+Generate shims for all managed commands
+
+USAGE:
+    alt shim
+
+OPTIONS:
+    -h, --help    Print help information
+'''
+stderr = ''

--- a/tests/snapshots/help_test__help@shim_--help.snap
+++ b/tests/snapshots/help_test__help@shim_--help.snap
@@ -4,13 +4,11 @@ expression: snapshot
 ---
 status = 0
 stdout = '''
-alt-shim 
 Generate shims for all managed commands
 
-USAGE:
-    alt shim
+Usage: alt shim
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help information
 '''
 stderr = ''

--- a/tests/snapshots/help_test__help@shim_-h.snap
+++ b/tests/snapshots/help_test__help@shim_-h.snap
@@ -1,0 +1,16 @@
+---
+source: tests/help_test.rs
+expression: snapshot
+---
+status = 0
+stdout = '''
+alt-shim 
+Generate shims for all managed commands
+
+USAGE:
+    alt shim
+
+OPTIONS:
+    -h, --help    Print help information
+'''
+stderr = ''

--- a/tests/snapshots/help_test__help@shim_-h.snap
+++ b/tests/snapshots/help_test__help@shim_-h.snap
@@ -4,13 +4,11 @@ expression: snapshot
 ---
 status = 0
 stdout = '''
-alt-shim 
 Generate shims for all managed commands
 
-USAGE:
-    alt shim
+Usage: alt shim
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help information
 '''
 stderr = ''

--- a/tests/snapshots/help_test__help@show_--help.snap
+++ b/tests/snapshots/help_test__help@show_--help.snap
@@ -1,0 +1,16 @@
+---
+source: tests/help_test.rs
+expression: snapshot
+---
+status = 0
+stdout = '''
+alt-show 
+Print commands and their versions
+
+USAGE:
+    alt show
+
+OPTIONS:
+    -h, --help    Print help information
+'''
+stderr = ''

--- a/tests/snapshots/help_test__help@show_--help.snap
+++ b/tests/snapshots/help_test__help@show_--help.snap
@@ -4,13 +4,11 @@ expression: snapshot
 ---
 status = 0
 stdout = '''
-alt-show 
 Print commands and their versions
 
-USAGE:
-    alt show
+Usage: alt show
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help information
 '''
 stderr = ''

--- a/tests/snapshots/help_test__help@show_-h.snap
+++ b/tests/snapshots/help_test__help@show_-h.snap
@@ -1,0 +1,16 @@
+---
+source: tests/help_test.rs
+expression: snapshot
+---
+status = 0
+stdout = '''
+alt-show 
+Print commands and their versions
+
+USAGE:
+    alt show
+
+OPTIONS:
+    -h, --help    Print help information
+'''
+stderr = ''

--- a/tests/snapshots/help_test__help@show_-h.snap
+++ b/tests/snapshots/help_test__help@show_-h.snap
@@ -4,13 +4,11 @@ expression: snapshot
 ---
 status = 0
 stdout = '''
-alt-show 
 Print commands and their versions
 
-USAGE:
-    alt show
+Usage: alt show
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help information
 '''
 stderr = ''

--- a/tests/snapshots/help_test__help@use_--help.snap
+++ b/tests/snapshots/help_test__help@use_--help.snap
@@ -4,18 +4,16 @@ expression: snapshot
 ---
 status = 0
 stdout = '''
-alt-use 
 Switch the version of a command
 
-USAGE:
-    alt use <command> [version]
+Usage: alt use <command> [version]
 
-ARGS:
-    <command>    Command to switch the version of
-    <version>    Version to use (optional)
+Arguments:
+  <command>  Command to switch the version of
+  [version]  Version to use (optional)
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help information
 
 EXAMPLES:
     alt use node 8        Use version 8 of node

--- a/tests/snapshots/help_test__help@use_--help.snap
+++ b/tests/snapshots/help_test__help@use_--help.snap
@@ -1,0 +1,25 @@
+---
+source: tests/help_test.rs
+expression: snapshot
+---
+status = 0
+stdout = '''
+alt-use 
+Switch the version of a command
+
+USAGE:
+    alt use <command> [version]
+
+ARGS:
+    <command>    Command to switch the version of
+    <version>    Version to use (optional)
+
+OPTIONS:
+    -h, --help    Print help information
+
+EXAMPLES:
+    alt use node 8        Use version 8 of node
+    alt use node          Prompt for a version of node to use
+    alt use node system   Use the system version of node
+'''
+stderr = ''

--- a/tests/snapshots/help_test__help@use_-h.snap
+++ b/tests/snapshots/help_test__help@use_-h.snap
@@ -4,18 +4,16 @@ expression: snapshot
 ---
 status = 0
 stdout = '''
-alt-use 
 Switch the version of a command
 
-USAGE:
-    alt use <command> [version]
+Usage: alt use <command> [version]
 
-ARGS:
-    <command>    Command to switch the version of
-    <version>    Version to use (optional)
+Arguments:
+  <command>  Command to switch the version of
+  [version]  Version to use (optional)
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help information
 
 EXAMPLES:
     alt use node 8        Use version 8 of node

--- a/tests/snapshots/help_test__help@use_-h.snap
+++ b/tests/snapshots/help_test__help@use_-h.snap
@@ -1,0 +1,25 @@
+---
+source: tests/help_test.rs
+expression: snapshot
+---
+status = 0
+stdout = '''
+alt-use 
+Switch the version of a command
+
+USAGE:
+    alt use <command> [version]
+
+ARGS:
+    <command>    Command to switch the version of
+    <version>    Version to use (optional)
+
+OPTIONS:
+    -h, --help    Print help information
+
+EXAMPLES:
+    alt use node 8        Use version 8 of node
+    alt use node          Prompt for a version of node to use
+    alt use node system   Use the system version of node
+'''
+stderr = ''

--- a/tests/snapshots/help_test__help@which_--help.snap
+++ b/tests/snapshots/help_test__help@which_--help.snap
@@ -4,16 +4,14 @@ expression: snapshot
 ---
 status = 0
 stdout = '''
-alt-which 
 Print the resolved path of a command
 
-USAGE:
-    alt which <command>
+Usage: alt which <command>
 
-ARGS:
-    <command>    Command to look up
+Arguments:
+  <command>  Command to look up
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help information
 '''
 stderr = ''

--- a/tests/snapshots/help_test__help@which_--help.snap
+++ b/tests/snapshots/help_test__help@which_--help.snap
@@ -1,0 +1,19 @@
+---
+source: tests/help_test.rs
+expression: snapshot
+---
+status = 0
+stdout = '''
+alt-which 
+Print the resolved path of a command
+
+USAGE:
+    alt which <command>
+
+ARGS:
+    <command>    Command to look up
+
+OPTIONS:
+    -h, --help    Print help information
+'''
+stderr = ''

--- a/tests/snapshots/help_test__help@which_-h.snap
+++ b/tests/snapshots/help_test__help@which_-h.snap
@@ -4,16 +4,14 @@ expression: snapshot
 ---
 status = 0
 stdout = '''
-alt-which 
 Print the resolved path of a command
 
-USAGE:
-    alt which <command>
+Usage: alt which <command>
 
-ARGS:
-    <command>    Command to look up
+Arguments:
+  <command>  Command to look up
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help information
 '''
 stderr = ''

--- a/tests/snapshots/help_test__help@which_-h.snap
+++ b/tests/snapshots/help_test__help@which_-h.snap
@@ -1,0 +1,19 @@
+---
+source: tests/help_test.rs
+expression: snapshot
+---
+status = 0
+stdout = '''
+alt-which 
+Print the resolved path of a command
+
+USAGE:
+    alt which <command>
+
+ARGS:
+    <command>    Command to look up
+
+OPTIONS:
+    -h, --help    Print help information
+'''
+stderr = ''

--- a/tests/test_env.rs
+++ b/tests/test_env.rs
@@ -1,3 +1,13 @@
+// We have to disable the `dead_code` warning here because while all of the code
+// here is used at least once, it's not used in every single test file which
+// causes a false positive on the warning. This happens because every test file
+// is built as its own executable and every single one of those can potentially
+// emit that warnings.
+// See:
+// - https://github.com/rust-lang/rust/issues/46379
+// - https://stackoverflow.com/a/67902444
+#![allow(dead_code)]
+
 use escargot::CargoBuild;
 use rand::distributions::Alphanumeric;
 use rand::prelude::*;

--- a/tests/test_env.rs
+++ b/tests/test_env.rs
@@ -1,10 +1,6 @@
-extern crate assert_cmd;
-extern crate escargot;
-extern crate rand;
-
-use self::escargot::CargoBuild;
-use self::rand::distributions::Alphanumeric;
-use self::rand::prelude::*;
+use escargot::CargoBuild;
+use rand::distributions::Alphanumeric;
+use rand::prelude::*;
 use std::env;
 use std::ffi::OsStr;
 use std::fs;


### PR DESCRIPTION
Supersedes #252 & #251 

The main change here is the upgrade to `clap` but there are a few changes and cleanups that I did while doing the migration:
- Remove some of the useless `extern crate ...` declarations
- Add a `CONTIRBUTING.md` file. The existing doc was moved from the readme.
- Add snapshot based tests for the help text