### PR TITLE
Ensure that `alt def` always stores an absolute path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rewrite how command versions are managed internally. This is a purely internal
   change and should not affect users in any way.
 
+### Fixed
+
+- Ensure `alt def` always stores the binary path it is given as an absolute
+  path. This fixes an issue where `alt` would fail to run a command version if
+  it was defined using a relative path.
+  ([#274](https://github.com/dotboris/alt/issues/274))
+
 <!-- section:previous-releases -->
 ## [v1.2.1] 2022-06-24
 

--- a/src/def_cmd.rs
+++ b/src/def_cmd.rs
@@ -15,7 +15,7 @@ pub fn run(command: &str, version: &str, bin: &str) -> anyhow::Result<()> {
     }
 
     let mut registry = load_command_version_registry()?;
-    registry.add(CommandVersion::new(command, version, &bin_path));
+    registry.add(CommandVersion::new(command, version, &bin_path))?;
     registry
         .save()
         .context("failed to save command version registry file")?;

--- a/src/def_cmd.rs
+++ b/src/def_cmd.rs
@@ -3,16 +3,12 @@ use crate::environment::load_command_version_registry;
 use crate::shim;
 use anyhow::Context;
 use std::env;
+use std::fs;
 use std::path::*;
-use std::process;
 
 pub fn run(command: &str, version: &str, bin: &str) -> anyhow::Result<()> {
-    let bin_path = PathBuf::from(bin);
-
-    if !bin_path.exists() {
-        println!("File not found: {}", bin);
-        process::exit(1);
-    }
+    let bin_path = fs::canonicalize(Path::new(bin))
+        .with_context(|| format!("failed to resolve {} to an absolute path", bin))?;
 
     let mut registry = load_command_version_registry()?;
     registry.add(CommandVersion::new(command, version, &bin_path))?;

--- a/src/scan_cmd.rs
+++ b/src/scan_cmd.rs
@@ -53,7 +53,7 @@ pub fn run(command: &str) -> anyhow::Result<()> {
 
             for choice in choices {
                 let version = versions[choice].clone();
-                command_version_registry.add(version);
+                command_version_registry.add(version)?;
             }
 
             command_version_registry


### PR DESCRIPTION
Fixes #274 